### PR TITLE
Xvector: Fixing Makefiles, path.sh

### DIFF
--- a/egs/swbd/s5c/path.sh
+++ b/egs/swbd/s5c/path.sh
@@ -1,4 +1,4 @@
 export KALDI_ROOT=`pwd`/../../..
-export PATH=$PWD/utils/:$KALDI_ROOT/src/bin:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/src/fstbin/:$KALDI_ROOT/src/gmmbin/:$KALDI_ROOT/src/featbin/:$KALDI_ROOT/src/lm/:$KALDI_ROOT/src/sgmmbin/:$KALDI_ROOT/src/sgmm2bin/:$KALDI_ROOT/src/fgmmbin/:$KALDI_ROOT/src/latbin/:$KALDI_ROOT/src/nnetbin:$KALDI_ROOT/src/nnet2bin:$KALDI_ROOT/src/nnet3bin:$KALDI_ROOT/src/online2bin/:$KALDI_ROOT/src/ivectorbin/:$KALDI_ROOT/src/lmbin/:$KALDI_ROOT/src/chainbin:$KALDI_ROOT/src/kwsbin:$PWD:$PATH
+export PATH=$PWD/utils/:$KALDI_ROOT/src/bin:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/src/fstbin/:$KALDI_ROOT/src/gmmbin/:$KALDI_ROOT/src/featbin/:$KALDI_ROOT/src/lm/:$KALDI_ROOT/src/sgmmbin/:$KALDI_ROOT/src/sgmm2bin/:$KALDI_ROOT/src/fgmmbin/:$KALDI_ROOT/src/latbin/:$KALDI_ROOT/src/nnetbin:$KALDI_ROOT/src/nnet2bin:$KALDI_ROOT/src/nnet3bin:$KALDI_ROOT/src/online2bin/:$KALDI_ROOT/src/ivectorbin/:$KALDI_ROOT/src/xvectorbin/:$KALDI_ROOT/src/lmbin/:$KALDI_ROOT/src/chainbin:$KALDI_ROOT/src/kwsbin:$PWD:$PATH
 
 export LC_ALL=C

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,13 +9,13 @@ SUBDIRS = base matrix util feat tree thread gmm transform sgmm \
           fstext hmm lm decoder lat kws cudamatrix nnet \
           bin fstbin gmmbin fgmmbin sgmmbin featbin \
           nnetbin latbin sgmm2 sgmm2bin nnet2 nnet3 chain nnet3bin nnet2bin kwsbin \
-          ivector ivectorbin online2 online2bin lmbin chainbin
+          ivector ivectorbin xvector xvectorbin online2 online2bin lmbin chainbin
 
 MEMTESTDIRS = base matrix util feat tree thread gmm transform sgmm \
           fstext hmm lm decoder lat nnet kws chain \
           bin fstbin gmmbin fgmmbin sgmmbin featbin \
           nnetbin latbin sgmm2 nnet2 nnet3 nnet2bin nnet3bin sgmm2bin kwsbin \
-          ivector ivectorbin online2 online2bin lmbin
+          ivector ivectorbin xvector xvectorbin online2 online2bin lmbin
 
 CUDAMEMTESTDIR = cudamatrix
 
@@ -145,9 +145,9 @@ $(EXT_SUBDIRS) : mklibdir
 # this is necessary for correct parallel compilation
 #1)The tools depend on all the libraries
 
-bin fstbin gmmbin fgmmbin sgmmbin sgmm2bin featbin nnetbin nnet2bin nnet3bin chainbin latbin ivectorbin lmbin kwsbin online2bin: \
+bin fstbin gmmbin fgmmbin sgmmbin sgmm2bin featbin nnetbin nnet2bin nnet3bin chainbin latbin ivectorbin xvectorbin lmbin kwsbin online2bin: \
  base matrix util feat tree optimization thread gmm transform sgmm sgmm2 fstext hmm \
- lm decoder lat cudamatrix nnet nnet2 nnet3 ivector
+ lm decoder lat cudamatrix nnet nnet2 nnet3 ivector xvector
 
 #2)The libraries have inter-dependencies
 base:
@@ -172,6 +172,7 @@ nnet2: base util matrix thread lat gmm hmm tree transform cudamatrix
 nnet3: base util matrix thread lat gmm hmm tree transform cudamatrix chain
 chain: lat hmm tree fstext matrix cudamatrix util base
 ivector: base util matrix thread transform tree gmm
+xvector: base util matrix cudamatrix nnet3
 #3)Dependencies for optional parts of Kaldi
 onlinebin: base matrix util feat tree optimization gmm transform sgmm sgmm2 fstext hmm lm decoder lat cudamatrix nnet nnet2 online thread
 # python-kaldi-decoding: base matrix util feat tree optimization thread gmm transform sgmm sgmm2 fstext hmm decoder lat online

--- a/src/ivector/Makefile
+++ b/src/ivector/Makefile
@@ -15,8 +15,7 @@ OBJFILES = ivector-extractor.o voice-activity-detection.o plda.o logistic-regres
 LIBNAME = kaldi-ivector
 
 ADDLIBS = ../gmm/kaldi-gmm.a ../tree/kaldi-tree.a ../transform/kaldi-transform.a \
-          ../thread/kaldi-thread.a ../nnet3/kaldi-nnet3.a ../cudamatrix/kaldi-cudamatrix.a \
-          ../matrix/kaldi-matrix.a ../base/kaldi-base.a \
+          ../thread/kaldi-thread.a ../matrix/kaldi-matrix.a ../base/kaldi-base.a \
           ../util/kaldi-util.a
 
 include ../makefiles/default_rules.mk

--- a/src/xvector/nnet-xvector-diagnostics.h
+++ b/src/xvector/nnet-xvector-diagnostics.h
@@ -18,8 +18,8 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef KALDI_NNET3_NNET_XVECTOR_DIAGNOSTICS_H_
-#define KALDI_NNET3_NNET_XVECTOR_DIAGNOSTICS_H_
+#ifndef KALDI_XVECTOR_NNET_XVECTOR_DIAGNOSTICS_H_
+#define KALDI_XVECTOR_NNET_XVECTOR_DIAGNOSTICS_H_
 
 #include "nnet3/nnet-example.h"
 #include "nnet3/nnet-computation.h"
@@ -89,4 +89,4 @@ class NnetXvectorComputeProb {
 } // namespace nnet3
 } // namespace kaldi
 
-#endif // KALDI_NNET3_NNET_XVECTOR_DIAGNOSTICS_H_
+#endif // KALDI_XVECTOR_NNET_XVECTOR_DIAGNOSTICS_H_

--- a/src/xvector/nnet-xvector-training.h
+++ b/src/xvector/nnet-xvector-training.h
@@ -18,8 +18,8 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef KALDI_IVECTOR_NNET_XVECTOR_TRAINING_H_
-#define KALDI_IVECTOR_NNET_XVECTOR_TRAINING_H_
+#ifndef KALDI_XVECTOR_NNET_XVECTOR_TRAINING_H_
+#define KALDI_XVECTOR_NNET_XVECTOR_TRAINING_H_
 
 #include "nnet3/nnet-example.h"
 #include "nnet3/nnet-computation.h"
@@ -86,4 +86,4 @@ void GetComputationRequestXvector(const Nnet &nnet,
 } // namespace nnet3
 } // namespace kaldi
 
-#endif // 
+#endif //

--- a/src/xvector/xvector.h
+++ b/src/xvector/xvector.h
@@ -18,8 +18,8 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef KALDI_IVECTOR_XVECTOR_H_
-#define KALDI_IVECTOR_XVECTOR_H_
+#ifndef KALDI_XVECTOR_XVECTOR_H_
+#define KALDI_XVECTOR_XVECTOR_H_
 
 #include <vector>
 #include "base/kaldi-common.h"

--- a/src/xvectorbin/Makefile
+++ b/src/xvectorbin/Makefile
@@ -6,7 +6,8 @@ include ../kaldi.mk
 LDFLAGS += $(CUDA_LDFLAGS)
 LDLIBS += $(CUDA_LDLIBS)
 
-BINFILES = nnet3-xvector-get-egs
+BINFILES = nnet3-xvector-get-egs nnet3-xvector-compute-prob \
+           nnet3-xvector-show-progress nnet3-xvector-train
 
 OBJFILES =
 
@@ -15,7 +16,7 @@ cuda-compiled.o: ../kaldi.mk
 
 TESTFILES =
 
-ADDLIBS = ../nnet3/kaldi-nnet3.a ../gmm/kaldi-gmm.a \
+ADDLIBS = ../xvector/kaldi-xvector.a ../nnet3/kaldi-nnet3.a ../gmm/kaldi-gmm.a \
          ../decoder/kaldi-decoder.a ../lat/kaldi-lat.a ../hmm/kaldi-hmm.a  \
          ../transform/kaldi-transform.a ../tree/kaldi-tree.a \
          ../thread/kaldi-thread.a ../cudamatrix/kaldi-cudamatrix.a \


### PR DESCRIPTION
Fixing Makefiles and paths after the xvector code was moved into src/xvector and src/xvectorbin. 