### PR TITLE
xvector: minor fix to prepare_perturbed_data.sh

### DIFF
--- a/egs/swbd/s5c/local/xvector/prepare_perturbed_data.sh
+++ b/egs/swbd/s5c/local/xvector/prepare_perturbed_data.sh
@@ -7,30 +7,30 @@
 set -e
 
 stage=1
-train_stage=-10
 generate_alignments=true # false if doing ctc training
 speed_perturb=true
+mfccdir=mfcc
+mfcc_config=conf/mfcc_hires.conf
 
 . ./path.sh
 . ./utils/parse_options.sh
 
 # perturbed data preparation
-train_set=train_nodup
 if [ $stage -le 1 ]; then
-  for datadir in train_nodup; do
-    if [ -d data/${datadir}_sp ]; then
-      echo "$0: directory ${datadir}_sp already exists, skipping creating it."
+  for dataset in train_nodup; do
+    if [ -d data/${dataset}_sp ]; then
+      echo "$0: directory data/${dataset}_sp already exists, skipping creating it."
     else
-      utils/data/perturb_data_dir_speed_3way.sh data/${datadir} data/${datadir}_sp
-      utils/data/perturb_data_dir_volume.sh data/${datadir}_sp
+      utils/data/perturb_data_dir_speed_3way.sh data/${dataset} data/${dataset}_sp
+      utils/data/perturb_data_dir_volume.sh data/${dataset}_sp
     fi
-    if [ -f data/${datadir}_sp_hires/feats.scp ]; then
-      echo "$0: directory data/${datadir}_sp_hires/feats.scp already exists, skipping creating it."
+    if [ -f data/${dataset}_sp_hires/feats.scp ]; then
+      echo "$0: directory data/${dataset}_sp_hires/feats.scp already exists, skipping creating it."
     else
-      mfccdir=mfcc
-      utils/copy_data_dir.sh data/${datadir}_sp data/${datadir}_sp_hires
+      utils/copy_data_dir.sh data/${dataset}_sp data/${dataset}_sp_hires
       steps/make_mfcc.sh --cmd "$train_cmd" --nj 50 \
-        data/${datadir}_sp_hires exp/make_mfcc/${datadir}_sp_hires $mfccdir || exit 1;
+        --mfcc-config $mfcc_config \
+        data/${dataset}_sp_hires exp/make_mfcc/${dataset}_sp_hires $mfccdir || exit 1;
       # we typically won't need the cmvn stats when using hires features-- it's
       # mostly for neural nets.
       utils/fix_data_dir.sh data/${dataset}_sp_hires  # remove segments with problems
@@ -50,9 +50,9 @@ if [ $stage -le 2 ]; then
       echo "$0: data/${dataset}_hires/feats.scp already exists, skipping mfcc generation"
     else
       utils/copy_data_dir.sh data/$dataset data/${dataset}_hires
-      steps/make_mfcc.sh --cmd "$train_cmd" --nj 10 --mfcc-config conf/mfcc_hires.conf \
-        data/${dataset}_hires exp/make_hires/$dataset $mfccdir;
-      steps/compute_cmvn_stats.sh data/${dataset}_hires exp/make_hires/$dataset $mfccdir;
+      steps/make_mfcc.sh --cmd "$train_cmd" --nj 10 --mfcc-config $mfcc_config \
+        data/${dataset}_hires exp/make_hires/$dataset $mfccdir
+      steps/compute_cmvn_stats.sh data/${dataset}_hires exp/make_hires/$dataset $mfccdir
       utils/fix_data_dir.sh data/${dataset}_hires  # remove segments with problems
     fi
   done


### PR DESCRIPTION
Just a minor fixes to the script: variable dataset was sometimes referred to as datadir in the first block, causing it to fail