### PR TITLE
xvector: computing accuracy during diagnostics 

### DIFF
--- a/egs/wsj/s5/steps/nnet3/xvector/train.sh
+++ b/egs/wsj/s5/steps/nnet3/xvector/train.sh
@@ -146,10 +146,10 @@ while [ $x -lt $num_iters ]; do
     if [ $[$x%$diagnostic_period] == 0 ]; then
       # Set off jobs doing some diagnostics, in the background.
       $cmd JOB=1:$num_diagnostic_archives $dir/log/compute_prob_valid.$x.JOB.log \
-        nnet3-xvector-compute-prob $dir/$x.raw \
+        nnet3-xvector-compute-prob --compute-accuracy=true $dir/$x.raw \
         "ark:nnet3-merge-egs --measure-output-frames=false ark:$egs_dir/valid_diagnostic_egs.JOB.ark ark:- |" &
       $cmd JOB=1:$num_diagnostic_archives $dir/log/compute_prob_train.$x.JOB.log \
-        nnet3-xvector-compute-prob $dir/$x.raw \
+        nnet3-xvector-compute-prob --compute-accuracy=true $dir/$x.raw \
         "ark:nnet3-merge-egs --measure-output-frames=false ark:$egs_dir/train_diagnostic_egs.JOB.ark ark:- |" &
     fi
     if [ $x -gt 0 ]; then

--- a/egs/wsj/s5/steps/nnet3/xvector/train.sh
+++ b/egs/wsj/s5/steps/nnet3/xvector/train.sh
@@ -15,6 +15,7 @@ num_jobs_initial=2 # Number of neural net jobs to run in parallel at the start o
 num_jobs_final=8   # Number of neural net jobs to run in parallel at the end of training
 stage=-3
 diagnostic_period=5
+compute_accuracy=true
 
 
 shuffle_buffer_size=1000 # This "buffer_size" variable controls randomization of the samples
@@ -137,10 +138,10 @@ while [ $x -lt $num_iters ]; do
     if [ $[$x%$diagnostic_period] == 0 ]; then
       # Set off jobs doing some diagnostics, in the background.
       $cmd JOB=1:$num_diagnostic_archives $dir/log/compute_prob_valid.$x.JOB.log \
-        nnet3-xvector-compute-prob --compute-accuracy=true $dir/$x.raw \
+        nnet3-xvector-compute-prob --compute-accuracy=${compute_accuracy} $dir/$x.raw \
         "ark:nnet3-merge-egs --measure-output-frames=false ark:$egs_dir/valid_diagnostic_egs.JOB.ark ark:- |" &
       $cmd JOB=1:$num_diagnostic_archives $dir/log/compute_prob_train.$x.JOB.log \
-        nnet3-xvector-compute-prob --compute-accuracy=true $dir/$x.raw \
+        nnet3-xvector-compute-prob --compute-accuracy=${compute_accuracy} $dir/$x.raw \
         "ark:nnet3-merge-egs --measure-output-frames=false ark:$egs_dir/train_diagnostic_egs.JOB.ark ark:- |" &
     fi
     if [ $x -gt 0 ]; then

--- a/src/xvector/nnet-xvector-diagnostics.cc
+++ b/src/xvector/nnet-xvector-diagnostics.cc
@@ -2,6 +2,7 @@
 
 // Copyright      2015    Johns Hopkins University (author: Daniel Povey)
 // Copyright      2016    Pegah Ghahremani
+//                        David Snyder
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +25,8 @@
 namespace kaldi {
 namespace nnet3 {
 
-NnetXvectorComputeProb::NnetXvectorComputeProb(const NnetComputeProbOptions &config,
+NnetXvectorComputeProb::NnetXvectorComputeProb(const NnetComputeProbOptions
+                                               &config,
                                                const Nnet &nnet):
     config_(config),
     nnet_(nnet),
@@ -81,28 +83,34 @@ void NnetXvectorComputeProb::ProcessOutputs(NnetComputer *computer) {
       std::string xvector_name = nnet_.GetNodeName(node_index),
         s_name = "s", b_name = "b";
       if (nnet_.GetNodeIndex(s_name) == -1 || nnet_.GetNodeIndex(b_name) == -1)
-        KALDI_ERR << "The nnet expected to have two output nodes with name s and b.";
+        KALDI_ERR << "The nnet expected to have two output nodes with "
+                  << "name s and b.";
 
       if (xvector_name != s_name && xvector_name != b_name) {
-        const CuMatrixBase<BaseFloat> &xvector_pairs = computer->GetOutput(xvector_name),
-          &xvec_s = computer->GetOutput(s_name),
-          &xvec_b = computer->GetOutput(b_name);
-        CuMatrix<BaseFloat> xvector_deriv(xvector_pairs.NumRows(), xvector_pairs.NumCols(),
-                                          kUndefined);
-        int32 s_dim = xvector_pairs.NumCols() * (xvector_pairs.NumCols() + 1) / 2;
+        const CuMatrixBase<BaseFloat> &xvector_pairs
+                                      = computer->GetOutput(xvector_name),
+                                      &xvec_s = computer->GetOutput(s_name),
+                                      &xvec_b = computer->GetOutput(b_name);
+        int32 num_rows = xvector_pairs.NumRows(),
+              num_cols = xvector_pairs.NumCols();
+        CuMatrix<BaseFloat> xvector_deriv(num_rows, num_cols, kUndefined),
+                            raw_scores(num_rows, num_rows, kUndefined);
+        int32 s_dim = num_cols * (num_cols + 1) / 2;
 
         // convert CuVector to CuSpMatrix
-        CuSpMatrix<BaseFloat> xvec_s_sp(xvector_pairs.NumCols());
+        CuSpMatrix<BaseFloat> xvec_s_sp(num_cols);
         xvec_s_sp.CopyFromVec(xvec_s.Row(0));
-
         CuVector<BaseFloat> deriv_s(s_dim);
+
         BaseFloat xvec_b_val = xvec_b(0,0), deriv_b;
         BaseFloat tot_weight, tot_objf;
         bool supply_deriv = config_.compute_deriv;
+        bool compute_accuracy = config_.compute_accuracy;
         ComputeXvectorObjfAndDeriv(xvector_pairs, xvec_s_sp, xvec_b_val,
                                    (supply_deriv ? &xvector_deriv : NULL),
                                    (supply_deriv ? &deriv_s : NULL),
                                    (supply_deriv ? &deriv_b : NULL),
+                                   (compute_accuracy ? &raw_scores : NULL),
                                    &tot_objf,
                                    &tot_weight);
         if (supply_deriv) {
@@ -118,6 +126,13 @@ void NnetXvectorComputeProb::ProcessOutputs(NnetComputer *computer) {
         SimpleObjectiveInfo &totals = objf_info_[xvector_name];
         totals.tot_weight += tot_weight;
         totals.tot_objective += tot_objf;
+        if (compute_accuracy) {
+          BaseFloat tot_acc, tot_weight_acc;
+          SimpleObjectiveInfo &acc_totals = acc_info_[xvector_name];
+          ComputeAccuracy(raw_scores, &tot_weight_acc, &tot_acc);
+          acc_totals.tot_objective += tot_weight_acc * tot_acc;
+          acc_totals.tot_weight += tot_weight_acc;
+        }
       }
       num_minibatches_processed_++;
     }
@@ -146,7 +161,45 @@ bool NnetXvectorComputeProb::PrintTotalStats() const {
         ans = true;
     }
   }
+  if (config_.compute_accuracy) {  // Now print the accuracy.
+    iter = acc_info_.begin();
+    end = acc_info_.end();
+    for (; iter != end; ++iter) {
+      const std::string &name = iter->first;
+      const SimpleObjectiveInfo &info = iter->second;
+      KALDI_LOG << "Overall accuracy for '" << name << "' is "
+                << (info.tot_objective / info.tot_weight)
+                << " per chunk"
+                << ", over " << ceil(info.tot_weight) << " chunks.";
+    }
+  }
   return ans;
+}
+
+void NnetXvectorComputeProb::ComputeAccuracy(
+    const CuMatrixBase<BaseFloat> &raw_scores,
+    BaseFloat *tot_weight_out,
+    BaseFloat *tot_accuracy_out) {
+  int32 num_rows = raw_scores.NumCols();
+  BaseFloat K = 1.0 / (num_rows - 2),
+            threshold = 0; // Corresponds to prob_same(u,v) = 0.5.
+  BaseFloat count = 0,
+        error = 0;
+  for (int32 i = 0; i < num_rows; i++) {
+    for (int32 j = 0; j < num_rows; j++) {
+      if (i + 1 == j && i % 2 == 0) {
+        if (raw_scores(i, j) < threshold)
+          error++;
+        count++;
+      } else if (i < j) {
+        if (raw_scores(i, j) >= threshold)
+          error += K;
+        count += K;
+      }
+    }
+  }
+  (*tot_accuracy_out) = 1.0 - static_cast<BaseFloat>(error) / count;
+  (*tot_weight_out) = count;
 }
 
 const SimpleObjectiveInfo* NnetXvectorComputeProb::GetObjective(

--- a/src/xvector/nnet-xvector-diagnostics.h
+++ b/src/xvector/nnet-xvector-diagnostics.h
@@ -71,7 +71,10 @@ class NnetXvectorComputeProb {
   ~NnetXvectorComputeProb();
  private:
   void ProcessOutputs(NnetComputer *computer);
-
+  // Computes the accuracy for this minibatch.
+  void ComputeAccuracy(const CuMatrixBase<BaseFloat> &raw_scores,
+                       BaseFloat *tot_weight_out,
+                       BaseFloat *tot_accuracy_out);
   NnetComputeProbOptions config_;
   const Nnet &nnet_;
 
@@ -82,6 +85,7 @@ class NnetXvectorComputeProb {
   int32 num_minibatches_processed_;
 
   unordered_map<std::string, SimpleObjectiveInfo, StringHasher> objf_info_;
+  unordered_map<std::string, SimpleObjectiveInfo, StringHasher> acc_info_;
 
 };
 

--- a/src/xvector/nnet-xvector-diagnostics.h
+++ b/src/xvector/nnet-xvector-diagnostics.h
@@ -73,7 +73,6 @@ class NnetXvectorComputeProb {
   void ProcessOutputs(NnetComputer *computer);
   // Computes the accuracy for this minibatch.
   void ComputeAccuracy(const CuMatrixBase<BaseFloat> &raw_scores,
-                       BaseFloat *tot_weight_out,
                        BaseFloat *tot_accuracy_out);
   NnetComputeProbOptions config_;
   const Nnet &nnet_;

--- a/src/xvector/xvector-test.cc
+++ b/src/xvector/xvector-test.cc
@@ -58,7 +58,7 @@ bool TestXvectorExtractorDerivative(BaseFloat perturb_delta) {
   CuVector<BaseFloat> deriv_S(S_dim, kSetZero);
   xvector_pairs.SetRandn();
   ComputeXvectorObjfAndDeriv(xvector_pairs, S, b, &deriv_xvector,
-    &deriv_S, &deriv_b, &tot_objf, &tot_weight);
+    &deriv_S, &deriv_b, NULL, &tot_objf, &tot_weight);
   CuVector<BaseFloat> deriv_xvector_vec(xvector_dim);
 
   // Sum over the derivatives for xvector input.
@@ -80,9 +80,9 @@ bool TestXvectorExtractorDerivative(BaseFloat perturb_delta) {
     BaseFloat tot_objf_p,
         tot_objf_n;
     ComputeXvectorObjfAndDeriv(xvector_pairs_p, S, b, NULL,
-      NULL, NULL, &tot_objf_p, &tot_weight);
+      NULL, NULL, NULL, &tot_objf_p, &tot_weight);
     ComputeXvectorObjfAndDeriv(xvector_pairs_n, S, b, NULL,
-      NULL, NULL, &tot_objf_n, &tot_weight);
+      NULL, NULL, NULL, &tot_objf_n, &tot_weight);
     BaseFloat delta = (tot_objf_p  - tot_objf_n)
       * 1.0 / (2.0 * perturb_delta);
     l2_xvector += pow(deriv_xvector_vec(i) - delta, 2);
@@ -100,9 +100,9 @@ bool TestXvectorExtractorDerivative(BaseFloat perturb_delta) {
     BaseFloat tot_objf_p,
               tot_objf_n;
     ComputeXvectorObjfAndDeriv(xvector_pairs, S_p, b, NULL,
-      NULL, NULL, &tot_objf_p, &tot_weight);
+      NULL, NULL, NULL, &tot_objf_p, &tot_weight);
     ComputeXvectorObjfAndDeriv(xvector_pairs, S_n, b, NULL,
-      NULL, NULL, &tot_objf_n, &tot_weight);
+      NULL, NULL, NULL, &tot_objf_n, &tot_weight);
     BaseFloat delta = (tot_objf_p  - tot_objf_n)
       * 1.0 / (2.0 * perturb_delta);
     l2_S += pow(deriv_S(i) - delta, 2);
@@ -115,9 +115,9 @@ bool TestXvectorExtractorDerivative(BaseFloat perturb_delta) {
   BaseFloat tot_objf_p;
   BaseFloat tot_objf_n;
   ComputeXvectorObjfAndDeriv(xvector_pairs, S, b_p, NULL,
-    NULL, NULL, &tot_objf_p, &tot_weight);
+    NULL, NULL, NULL, &tot_objf_p, &tot_weight);
   ComputeXvectorObjfAndDeriv(xvector_pairs, S, b_n, NULL,
-    NULL, NULL, &tot_objf_n, &tot_weight);
+    NULL, NULL, NULL, &tot_objf_n, &tot_weight);
   BaseFloat delta = (tot_objf_p  - tot_objf_n)
                     * 1.0 / (2.0 * perturb_delta);
   l2_b = pow(deriv_b - delta, 2);
@@ -151,7 +151,7 @@ bool TestXvectorComputeObjf() {
   xvector_pairs.SetRandn();
 
   ComputeXvectorObjfAndDeriv(xvector_pairs, S, b, &deriv_xvector,
-    &deriv_S, &deriv_b, &tot_objf, &tot_weight);
+    &deriv_S, &deriv_b, NULL, &tot_objf, &tot_weight);
   TestComputeXvectorObjfAndDeriv(xvector_pairs, S, b, &deriv_xvector_test,
     &deriv_S_test, &deriv_b_test, &tot_objf_test, &tot_weight_test);
 

--- a/src/xvector/xvector.cc
+++ b/src/xvector/xvector.cc
@@ -26,6 +26,7 @@ void ComputeXvectorObjfAndDeriv(
     const CuSpMatrix<BaseFloat> &S,
     BaseFloat b, CuMatrixBase<BaseFloat> *deriv_xvector,
     CuVector<BaseFloat> *deriv_S, BaseFloat *deriv_b,
+    CuMatrixBase<BaseFloat> *scores_out,
     BaseFloat *tot_objf,
     BaseFloat *tot_weight) {
 
@@ -40,10 +41,10 @@ void ComputeXvectorObjfAndDeriv(
     KALDI_ASSERT(deriv_xvector->NumCols() == xvector_dim);
     KALDI_ASSERT(deriv_xvector->NumRows() == N);
     KALDI_ASSERT(deriv_S->Dim() == S_dim);
-    deriv_xvector->Set(0.0);
-    deriv_S->Set(0.0);
-    (*deriv_b) = 0.0;
+    deriv_xvector->SetZero();
+    deriv_S->SetZero();
   }
+
 
   CuMatrix<BaseFloat> S_tmp(S),
                       P(N, xvector_dim),
@@ -64,6 +65,11 @@ void ComputeXvectorObjfAndDeriv(
   scores.AddMat(-1.0, R, kTrans);
   scores.AddMat(-1.0, R, kNoTrans);
   scores.Add(b);
+  if (scores_out != NULL) {
+    KALDI_ASSERT(scores_out->NumCols() == scores.NumCols()
+                 && scores_out->NumRows() == scores.NumRows());
+    scores_out->CopyFromMat(scores);
+  }
 
   cu::ComputeXvectorObjfFromScores(scores, &objf_terms, &scores_deriv);
   CuVector<BaseFloat> objf_terms_vec(N);

--- a/src/xvector/xvector.h
+++ b/src/xvector/xvector.h
@@ -69,6 +69,7 @@ namespace kaldi {
     CuMatrixBase<BaseFloat> *deriv_xvector,
     CuVector<BaseFloat> *deriv_S,
     BaseFloat *deriv_b,
+    CuMatrixBase<BaseFloat> *scores_out,
     BaseFloat *tot_objf,
     BaseFloat *tot_weight);
 }  // namespace kaldi


### PR DESCRIPTION
Added ComputeAccuracy to nnet-xvector-diagnostics, which computes the same/diff classification accuracy using the raw scores.

Had to change the interface to ComputeXvectorObjfAndDeriv so that it can optionally output the raw scores (e.g., L = u.v - vSv ...)