### PR TITLE
Xvector: Adding nnet3-xvector-compute

### DIFF
--- a/src/xvector/Makefile
+++ b/src/xvector/Makefile
@@ -10,7 +10,7 @@ LDLIBS += $(CUDA_LDLIBS)
 
 TESTFILES = xvector-test
 
-OBJFILES = xvector.o nnet-xvector-training.o nnet-xvector-diagnostics.o 
+OBJFILES = xvector.o nnet-xvector-training.o nnet-xvector-diagnostics.o nnet-xvector-compute.o
 
 LIBNAME = kaldi-xvector
 

--- a/src/xvector/nnet-xvector-compute.cc
+++ b/src/xvector/nnet-xvector-compute.cc
@@ -1,0 +1,117 @@
+// xvector/nnet-xvector-compute.cc
+
+// Copyright      2015    Johns Hopkins University (author: Daniel Povey)
+//                2016    David Snyder
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xvector/nnet-xvector-compute.h"
+#include "nnet3/nnet-utils.h"
+
+namespace kaldi {
+namespace nnet3 {
+
+NnetXvectorComputer::NnetXvectorComputer(
+    const NnetSimpleComputationOptions &config,
+    Nnet *nnet):
+    nnet_(nnet),
+    config_(config),
+    compiler_(*nnet, config.optimize_config) {
+}
+
+void NnetXvectorComputer::ComputeXvector(const MatrixBase<BaseFloat> &feats,
+                    Vector<BaseFloat> *xvector) {
+
+  ComputationRequest request;
+  GetComputationRequest(feats, &request);
+  const NnetComputation *computation = compiler_.Compile(request);
+  NnetComputer computer(config_.compute_config, *computation,
+                        *nnet_,
+                        nnet_);
+  std::string input_name = "input";
+  CuMatrix<BaseFloat> cu_feats(feats);
+  computer.AcceptInput(input_name, &cu_feats);
+  computer.Forward();
+  const CuMatrixBase<BaseFloat> &output = computer.GetOutput("output");
+  KALDI_ASSERT(output.NumRows() == 1 && output.NumCols() == xvector->Dim());
+  CuSubVector<BaseFloat> xvector_tmp(output, 0);
+  xvector->CopyFromVec(xvector_tmp);
+}
+
+void NnetXvectorComputer::GetComputationRequest(
+    const MatrixBase<BaseFloat> &feats,
+    ComputationRequest *request) {
+  std::string input_name = "input",
+              output_name = "output";
+  NnetIo nnet_io = NnetIo(input_name, 0, feats);
+  request->inputs.clear();
+  request->outputs.clear();
+  request->inputs.resize(1);
+  request->outputs.resize(1);
+  request->need_model_derivative = false;
+  request->store_component_stats = false;
+
+  int32 input_node_index = nnet_->GetNodeIndex(input_name);
+
+  if (input_node_index == -1 && !nnet_->IsInputNode(input_node_index))
+    KALDI_ERR << "No input node called '" << input_name
+              << "' in the network.";
+
+  request->inputs[0].name = input_name;
+  request->inputs[0].indexes = nnet_io.indexes;
+  request->inputs[0].has_deriv = false;
+
+  // We only need the output on frame t=0.
+  int32 io_index_size = request->inputs[0].indexes.size(),
+         n_indx_size = 1e6, t_ind;
+  std::vector<Index> output_indexes;
+
+  std::map<int32, int32> n_indx_sizes;
+  for (int32 indx = 0; indx < io_index_size; indx++) {
+    t_ind = request->inputs[0].indexes[indx].t;
+    if (n_indx_sizes.count(t_ind) != 0)
+      n_indx_sizes[t_ind] += 1;
+    else
+      n_indx_sizes.insert(std::make_pair(t_ind, 1));
+  }
+  std::map<int32, int32>::const_iterator iter;
+  for (iter = n_indx_sizes.begin(); iter != n_indx_sizes.end(); iter++)
+    n_indx_size = std::min(n_indx_size, iter->second);
+
+  output_indexes.resize(n_indx_size);
+  for (int32 indx = 0; indx < n_indx_size; indx++) {
+    output_indexes[indx].n = indx;
+    output_indexes[indx].t = 0;
+  }
+
+  // In order to generate a computation request for the output node,
+  // we should find output nodes and add io_spec for each one.
+  int32 output_node_index = nnet_->GetNodeIndex(output_name);
+  if (!nnet_->IsOutputNode(output_node_index))
+    KALDI_ERR << "No output node called '" << input_name
+              << "' in the network.";
+  request->outputs[0].name = output_name;
+  request->outputs[0].indexes = output_indexes;
+  request->outputs[0].has_deriv = false;
+
+  // check to see if something went wrong.
+  if (request->inputs.empty())
+    KALDI_ERR << "No input in computation request.";
+  if (request->outputs.empty())
+    KALDI_ERR << "No output in computation request.";
+}
+
+} // namespace nnet3
+} // namespace kaldi

--- a/src/xvector/nnet-xvector-compute.cc
+++ b/src/xvector/nnet-xvector-compute.cc
@@ -99,7 +99,7 @@ void NnetXvectorComputer::GetComputationRequest(
   // Add an io_spec for the output node.
   int32 output_node_index = nnet_->GetNodeIndex(output_name);
   if (!nnet_->IsOutputNode(output_node_index))
-    KALDI_ERR << "No output node called '" << input_name
+    KALDI_ERR << "No output node called '" << output_name
               << "' in the network.";
   request->outputs[0].name = output_name;
   request->outputs[0].indexes = output_indexes;

--- a/src/xvector/nnet-xvector-compute.cc
+++ b/src/xvector/nnet-xvector-compute.cc
@@ -96,8 +96,7 @@ void NnetXvectorComputer::GetComputationRequest(
     output_indexes[indx].t = 0;
   }
 
-  // In order to generate a computation request for the output node,
-  // we should find output nodes and add io_spec for each one.
+  // Add an io_spec for the output node.
   int32 output_node_index = nnet_->GetNodeIndex(output_name);
   if (!nnet_->IsOutputNode(output_node_index))
     KALDI_ERR << "No output node called '" << input_name

--- a/src/xvector/nnet-xvector-compute.h
+++ b/src/xvector/nnet-xvector-compute.h
@@ -1,0 +1,55 @@
+// xvector/nnet-xvector-compute.h
+
+// Copyright    2015  Johns Hopkins University (author: Daniel Povey)
+//              2016  David Snyder
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KALDI_XVECTOR_NNET_XVECTOR_COMPUTE_H_
+#define KALDI_XVECTOR_NNET_XVECTOR_COMPUTE_H_
+
+#include "nnet3/nnet-am-decodable-simple.h" // For NnetSimpleComputationOptions
+#include "nnet3/nnet-computation.h"
+#include "nnet3/nnet-compute.h"
+#include "xvector/xvector.h"
+
+namespace kaldi {
+namespace nnet3 {
+
+/**
+  class NnetXvectorComputer is responsible for extracting xvectors from
+  feature chunks.
+**/
+class NnetXvectorComputer {
+ public:
+  /// Constructor.
+  NnetXvectorComputer(const NnetSimpleComputationOptions &opts,
+                      Nnet *nnet);
+  /// Extracts an xvector given input features.
+  void ComputeXvector(const MatrixBase<BaseFloat> &feats,
+                    Vector<BaseFloat> *xvector);
+ private:
+  Nnet *nnet_;
+  const NnetSimpleComputationOptions config_;
+  CachingOptimizingCompiler compiler_;
+
+  /// Creates a computation request from the input features.
+  void GetComputationRequest(const MatrixBase<BaseFloat> &feats,
+                             ComputationRequest *request);
+};
+} // namespace nnet3
+} // namespace kaldi
+
+#endif //

--- a/src/xvector/nnet-xvector-training.cc
+++ b/src/xvector/nnet-xvector-training.cc
@@ -1,4 +1,4 @@
-// nnet3/nnet-xvector-training.cc
+// xvector/nnet-xvector-training.cc
 
 // Copyright      2015    Johns Hopkins University (author: Daniel Povey)
 //                2015    Xiaohui Zhang

--- a/src/xvector/nnet-xvector-training.h
+++ b/src/xvector/nnet-xvector-training.h
@@ -1,8 +1,8 @@
-// nnet3/nnet-xvector-training.h
+// xvector/nnet-xvector-training.h
 
 // Copyright    2015  Johns Hopkins University (author: Daniel Povey)
 //              2016  Xiaohui Zhang
-// Copyright    2016    Pegah Ghahremani
+// Copyright    2016  Pegah Ghahremani
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/xvectorbin/Makefile
+++ b/src/xvectorbin/Makefile
@@ -7,7 +7,8 @@ LDFLAGS += $(CUDA_LDFLAGS)
 LDLIBS += $(CUDA_LDLIBS)
 
 BINFILES = nnet3-xvector-get-egs nnet3-xvector-compute-prob \
-           nnet3-xvector-show-progress nnet3-xvector-train
+           nnet3-xvector-show-progress nnet3-xvector-train \
+           nnet3-xvector-compute
 
 OBJFILES =
 

--- a/src/xvectorbin/nnet3-xvector-compute.cc
+++ b/src/xvectorbin/nnet3-xvector-compute.cc
@@ -1,0 +1,112 @@
+// nnet3bin/nnet3-compute.cc
+
+// Copyright 2012-2015   Johns Hopkins University (author: Daniel Povey)
+//                2016   David Snyder
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "base/kaldi-common.h"
+#include "util/common-utils.h"
+#include "base/timer.h"
+#include "nnet3/nnet-utils.h"
+#include "xvector/nnet-xvector-compute.h"
+
+
+int main(int argc, char *argv[]) {
+  try {
+    using namespace kaldi;
+    using namespace kaldi::nnet3;
+    typedef kaldi::int32 int32;
+    typedef kaldi::int64 int64;
+
+    const char *usage =
+      "Propagate the features through the network and write the output\n"
+      "xvectors.  The xvector system assumes that for one input feature\n"
+      "matrix, regardless of the number of rows, there is only one output\n"
+      "xvector.  If the input has more rows than the network context, the\n"
+      "extra rows will not be used in the xvector computation.\n"
+      "\n"
+      "Usage: nnet3-xvector-compute [options] <raw-nnet-in> "
+      "<feats-rspecifier> <vector-wspecifier>\n"
+      " e.g.: nnet3-xvector-compute final.raw scp:feats.scp "
+      "ark:xvectors.ark\n";
+
+    ParseOptions po(usage);
+    Timer timer;
+
+    NnetSimpleComputationOptions opts;
+    std::string use_gpu = "yes";
+
+    opts.Register(&po);
+
+    po.Register("use-gpu", &use_gpu,
+                "yes|no|optional|wait, only has effect if compiled with CUDA");
+
+    po.Read(argc, argv);
+
+    if (po.NumArgs() != 3) {
+      po.PrintUsage();
+      exit(1);
+    }
+
+#if HAVE_CUDA==1
+    CuDevice::Instantiate().SelectGpuId(use_gpu);
+#endif
+
+    std::string nnet_rxfilename = po.GetArg(1),
+                feat_rspecifier = po.GetArg(2),
+                vector_wspecifier = po.GetArg(3);
+
+    Nnet nnet;
+    ReadKaldiObject(nnet_rxfilename, &nnet);
+    NnetXvectorComputer nnet_computer(opts, &nnet);
+
+    BaseFloatVectorWriter vector_writer(vector_wspecifier);
+
+    int32 num_success = 0, num_fail = 0;
+    int64 frame_count = 0;
+
+    SequentialBaseFloatMatrixReader feat_reader(feat_rspecifier);
+    for (; !feat_reader.Done(); feat_reader.Next()) {
+      std::string utt = feat_reader.Key();
+      const Matrix<BaseFloat> &feats (feat_reader.Value());
+      if (feats.NumRows() == 0) {
+        KALDI_WARN << "Zero-length utterance: " << utt;
+        num_fail++;
+        continue;
+      }
+      Vector<BaseFloat> xvector(nnet.OutputDim("output"));
+      nnet_computer.ComputeXvector(feats, &xvector);
+      vector_writer.Write(utt, xvector);
+      frame_count += feats.NumRows();
+      num_success++;
+    }
+
+    double elapsed = timer.Elapsed();
+    KALDI_LOG << "Time taken "<< elapsed
+              << "s: real-time factor assuming 100 frames/sec is "
+              << (elapsed*100.0/frame_count);
+    KALDI_LOG << "Done " << num_success << " utterances, failed for "
+              << num_fail;
+
+    if (num_success != 0) return 0;
+    else return 1;
+  } catch(const std::exception &e) {
+    std::cerr << e.what();
+    return -1;
+  }
+}


### PR DESCRIPTION
Adding binary nnet3-xvector-compute and nnet-xvector-compute.{cc.h}. Correcting typos in some files. 

This code is responsible for extracting xvectors from the nnet, given some input features.