### PR TITLE
xvector: updating nnet3-xvector-compute

### DIFF
--- a/src/xvector/nnet-xvector-diagnostics.cc
+++ b/src/xvector/nnet-xvector-diagnostics.cc
@@ -1,4 +1,4 @@
-// nnet3/nnet-xvector-diagnostics.cc
+// xvector/nnet-xvector-diagnostics.cc
 
 // Copyright      2015    Johns Hopkins University (author: Daniel Povey)
 // Copyright      2016    Pegah Ghahremani

--- a/src/xvector/nnet-xvector-diagnostics.h
+++ b/src/xvector/nnet-xvector-diagnostics.h
@@ -1,4 +1,4 @@
-// nnet3/nnet-xvector-diagnostics.h
+// xvector/nnet-xvector-diagnostics.h
 
 // Copyright    2015  Johns Hopkins University (author: Daniel Povey)
 // Copyright    2016  Pegah Ghahremani

--- a/src/xvectorbin/nnet3-xvector-compute.cc
+++ b/src/xvectorbin/nnet3-xvector-compute.cc
@@ -25,7 +25,6 @@
 #include "nnet3/nnet-utils.h"
 #include "xvector/nnet-xvector-compute.h"
 
-
 int main(int argc, char *argv[]) {
   try {
     using namespace kaldi;
@@ -35,27 +34,42 @@ int main(int argc, char *argv[]) {
 
     const char *usage =
       "Propagate the features through the network and write the output\n"
-      "xvectors.  The xvector system assumes that for one input feature\n"
-      "matrix, regardless of the number of rows, there is only one output\n"
-      "xvector.  If the input has more rows than the network context, the\n"
-      "extra rows will not be used in the xvector computation.\n"
+      "xvectors.  By default, xvectors are extracted once every\n"
+      "--xvector-period using --chunk-size frames and output as an archive\n"
+      "of matrices.  If --repeat=true, the xvectors are copied between\n"
+      "periods, so that the output matrix has the same number of rows as\n"
+      "the input.  If --output-as-vector=true, the xvectors are averaged\n"
+      "across periods, and the output is a single vector for each utterance.\n"
       "\n"
       "Usage: nnet3-xvector-compute [options] <raw-nnet-in> "
-      "<feats-rspecifier> <vector-wspecifier>\n"
-      " e.g.: nnet3-xvector-compute final.raw scp:feats.scp "
-      "ark:xvectors.ark\n";
+      "<feats-rspecifier> <xvector-wspecifier>\n"
+      " e.g.: nnet3-xvector-compute --xvector-period=50 final.raw "
+      "scp:feats.scp ark:xvectors.ark\n";
 
     ParseOptions po(usage);
     Timer timer;
 
     NnetSimpleComputationOptions opts;
     std::string use_gpu = "yes";
+    int32 xvector_period = 10,
+          chunk_size = -1;
+    bool output_as_vector = false,
+         repeat = false;
 
     opts.Register(&po);
 
     po.Register("use-gpu", &use_gpu,
                 "yes|no|optional|wait, only has effect if compiled with CUDA");
-
+    po.Register("xvector-period", &xvector_period,
+      "Extract a new xvector once for each period.");
+    po.Register("chunk-size", &chunk_size,
+      "Feature chunk size over which the xvector is computed.  "
+      "If not set, defaults to xvector-period.");
+    po.Register("output-as-vector", &output_as_vector,
+      "If true, average the chunk-level xvectors and output as an "
+      "archive of vector.");
+    po.Register("repeat", &repeat, "If true, the xvectors are copied between "
+      "periods so that the output has the same number of rows as the input.");
     po.Read(argc, argv);
 
     if (po.NumArgs() != 3) {
@@ -67,31 +81,102 @@ int main(int argc, char *argv[]) {
     CuDevice::Instantiate().SelectGpuId(use_gpu);
 #endif
 
+    if (output_as_vector && repeat)
+      KALDI_ERR << "Options --output-as-vector and --repeat cannot both "
+                << "be true.";
+    if (chunk_size == -1)
+      chunk_size = xvector_period;
+    KALDI_ASSERT(chunk_size > 0 && xvector_period > 0);
+
     std::string nnet_rxfilename = po.GetArg(1),
                 feat_rspecifier = po.GetArg(2),
                 vector_wspecifier = po.GetArg(3);
-
     Nnet nnet;
     ReadKaldiObject(nnet_rxfilename, &nnet);
     NnetXvectorComputer nnet_computer(opts, &nnet);
 
-    BaseFloatVectorWriter vector_writer(vector_wspecifier);
+    BaseFloatMatrixWriter matrix_writer(output_as_vector
+        ? "" : vector_wspecifier);
+    BaseFloatVectorWriter vector_writer(output_as_vector
+        ? vector_wspecifier : "");
 
-    int32 num_success = 0, num_fail = 0;
+    int32 num_success = 0,
+          num_fail = 0,
+          xvector_dim = nnet.OutputDim("output");
     int64 frame_count = 0;
 
     SequentialBaseFloatMatrixReader feat_reader(feat_rspecifier);
     for (; !feat_reader.Done(); feat_reader.Next()) {
       std::string utt = feat_reader.Key();
       const Matrix<BaseFloat> &feats (feat_reader.Value());
-      if (feats.NumRows() == 0) {
-        KALDI_WARN << "Zero-length utterance: " << utt;
+      int32 num_rows = feats.NumRows(),
+            feat_dim = feats.NumCols();
+      if (num_rows < chunk_size) {
+        KALDI_WARN << "The chunk-size is greater than the number of rows "
+                   << "in utterance: " << utt;
         num_fail++;
         continue;
       }
-      Vector<BaseFloat> xvector(nnet.OutputDim("output"));
-      nnet_computer.ComputeXvector(feats, &xvector);
-      vector_writer.Write(utt, xvector);
+
+      int32 num_chunks = ceil((num_rows - chunk_size)
+            / static_cast<BaseFloat>(xvector_period)) + 1,
+            num_xvectors = repeat ? num_rows : ceil(num_rows
+            / static_cast<BaseFloat>(xvector_period));
+
+      // The number of frames by which the last two chunks overlap.
+      int32 overlap = std::max(0, (num_chunks - 1) * xvector_period
+                      - num_rows + chunk_size);
+      BaseFloat total_chunk_weight = 0.0;
+      Vector<BaseFloat> xvector_avg;
+      Matrix<BaseFloat> xvector_mat;
+
+      // Create the output xvector vector or matrix. Only allocate memory
+      // for the one we're goijg to output to.
+      if (output_as_vector)
+        xvector_avg.Resize(xvector_dim);
+      else
+        xvector_mat.Resize(num_xvectors, xvector_dim);
+
+      // Iterate over the feature chunks.
+      for (int32 chunk_indx = 0; chunk_indx < num_chunks; chunk_indx++) {
+        // If we're nearing the end of the input, we may need to shift the
+        // offset back so that we can get chunk_size frames of input to the
+        // nnet.
+        int32 offset = std::min(chunk_indx * xvector_period,
+                           num_rows - chunk_size);
+        SubMatrix<BaseFloat> sub_feats(feats, offset, chunk_size,
+                                       0, feat_dim);
+        Vector<BaseFloat> xvector(xvector_dim);
+        nnet_computer.ComputeXvector(sub_feats, &xvector);
+
+        if (output_as_vector) {
+          // The second to last chunk may have extra overlap with the
+          // final chunk. We need to reduce the weight on these
+          // chunks, so that the overlapping portion isn't counted twice.
+          BaseFloat weight;
+          if (chunk_indx < num_chunks - 2)
+            weight = chunk_size;
+          else
+            weight = chunk_size - 0.5 * overlap;
+          total_chunk_weight += weight;
+          xvector_avg.AddVec(weight, xvector);
+        // Cases for outputting as a matrix:
+        } else if (repeat) {
+          int32 out_offset = chunk_indx * xvector_period;
+          for (int32 i = out_offset;
+              i < std::min(out_offset + xvector_period, num_rows); i++)
+            xvector_mat.Row(i).CopyFromVec(xvector);
+        } else
+          xvector_mat.Row(chunk_indx).CopyFromVec(xvector);
+      }
+
+      // If output is a vector, scale it by the total weight.
+      if (output_as_vector) {
+        xvector_avg.Scale(1.0 / total_chunk_weight);
+        vector_writer.Write(utt, xvector_avg);
+      } else
+        matrix_writer.Write(utt, xvector_mat);
+
       frame_count += feats.NumRows();
       num_success++;
     }

--- a/src/xvectorbin/nnet3-xvector-compute.cc
+++ b/src/xvectorbin/nnet3-xvector-compute.cc
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
       "If not set, defaults to xvector-period.");
     po.Register("output-as-vector", &output_as_vector,
       "If true, average the chunk-level xvectors and output as an "
-      "archive of vector.");
+      "archive of vectors.");
     po.Register("repeat", &repeat, "If true, the xvectors are copied between "
       "periods so that the output has the same number of rows as the input.");
     po.Read(argc, argv);

--- a/src/xvectorbin/nnet3-xvector-compute.cc
+++ b/src/xvectorbin/nnet3-xvector-compute.cc
@@ -131,7 +131,7 @@ int main(int argc, char *argv[]) {
       Matrix<BaseFloat> xvector_mat;
 
       // Create the output xvector vector or matrix. Only allocate memory
-      // for the one we're goijg to output to.
+      // for the one we're going to output.
       if (output_as_vector)
         xvector_avg.Resize(xvector_dim);
       else


### PR DESCRIPTION
Updating nnet3-xvector-compute.

I added options to output as either a matrix or a vector. For the case of outputting as a matrix, there is a --repeat option which copies the xvectors between --xvector-periods so that the output matrix has the same number of rows as the input. Also added an option called --chunk-size, which specifies the size of the window we will compute over (it defaults to --xvector-period). The combination of the last two options allows us to extract xvectors from overlapping chunks. 

Unfortunately there's a bit of complexity needed to handle the issue of a short chunk at the end of the input. Because the DNN requires some minimum context, we frequently run into the issue that the final chunk is too small for the computation request. In order to handle this, the final chunk is shifted back, so that it is the same a size as the others. The weight of the final two xvectors are adjusted to compensate for the fact that we're oversampling the features at the end of the input. 