### PR TITLE
Xvector: another update to nnet3-xvector-compute

### DIFF
--- a/src/xvectorbin/nnet3-xvector-compute.cc
+++ b/src/xvectorbin/nnet3-xvector-compute.cc
@@ -125,9 +125,9 @@ int main(int argc, char *argv[]) {
         num_fail++;
         continue;
       } else if (num_rows < this_chunk_size) {
-        KALDI_LOG << "Chunk-size of " << this_chunk_size << " is greater than "
+        KALDI_LOG << "Chunk size of " << this_chunk_size << " is greater than "
                   << "the number of rows in utterance: " << utt
-                  << ", using chunk-size  of " << num_rows;
+                  << ", using chunk size  of " << num_rows;
         this_chunk_size = num_rows;
       }
 


### PR DESCRIPTION
Updating the nnet3-xvector-compute binary so that it better handles short utterances. Previously, the binary would pass over utterances that were less than the specified chunk-size. Now it reduces the chunk-size to feats.NumRows() if it is less than the chunk-size but greater than or equal to the minimum context of the DNN. 