### PR TITLE
xvector: printing eigenvalues of output s

### DIFF
--- a/src/nnet3/nnet-utils.cc
+++ b/src/nnet3/nnet-utils.cc
@@ -436,7 +436,7 @@ std::string SpMatrixOutputInfo(const Nnet &nnet) {
     // (1/2)*(d+1)*d.
     int32 output_dim = nnet.OutputDim(output_name);
     int32 d = (0.5) * (1 + sqrt(1 + 8 * output_dim)) - 1;
-    if ( ((d+1) * d) / 2 == output_dim) {
+    if (((d + 1) * d) / 2 == output_dim) {
       SpMatrix<BaseFloat> S(d);
       Vector<BaseFloat> s_vec(output_dim);
       GetConstantOutput(nnet, output_name, &s_vec);

--- a/src/nnet3/nnet-utils.h
+++ b/src/nnet3/nnet-utils.h
@@ -144,12 +144,22 @@ int32 NumUpdatableComponents(const Nnet &dest);
 void ConvertRepeatedToBlockAffine(Nnet *nnet);
 
 /// This function returns various info about the neural net.
-/// If the nnet satisfied IsSimpleNnet(nnet), the info includes "left-context=5\nright-context=3\n...".  The info includes
+/// If the nnet satisfied IsSimpleNnet(nnet), the info includes
+/// "left-context=5\nright-context=3\n...".  The info includes
 /// the output of nnet.Info().
 /// This is modeled after the info that AmNnetSimple returns in its
 /// Info() function (we need this in the CTC code).
 std::string NnetInfo(const Nnet &nnet);
 
+/// Returns a string containing info on an output node called 's' if
+/// it can be interpreted as a symmetric matrix.
+std::string SpMatrixOutputInfo(const Nnet &nnet);
+
+/// This function assumes that the node named in 'output_node' is a constant
+/// function of the input features (e.g, a ConstantFunctionComponent is
+/// its input) and returns it in 'out'.
+void GetConstantOutput(const Nnet &nnet, const std::string &output_name,
+      Vector<BaseFloat> *out);
 
 } // namespace nnet3
 } // namespace kaldi

--- a/src/nnet3bin/nnet3-info.cc
+++ b/src/nnet3bin/nnet3-info.cc
@@ -20,6 +20,7 @@
 #include "base/kaldi-common.h"
 #include "util/common-utils.h"
 #include "nnet3/nnet-nnet.h"
+#include "nnet3/nnet-utils.h"
 
 int main(int argc, char *argv[]) {
   try {
@@ -35,22 +36,23 @@ int main(int argc, char *argv[]) {
         "e.g.:\n"
         " nnet3-info 0.raw\n"
         "See also: nnet3-am-info\n";
-    
+
     ParseOptions po(usage);
-    
+
     po.Read(argc, argv);
-    
+
     if (po.NumArgs() != 1) {
       po.PrintUsage();
       exit(1);
     }
 
     std::string raw_nnet_rxfilename = po.GetArg(1);
-    
+
     Nnet nnet;
     ReadKaldiObject(raw_nnet_rxfilename, &nnet);
 
     std::cout << nnet.Info();
+    std::cout << SpMatrixOutputInfo(nnet);
 
     return 0;
   } catch(const std::exception &e) {
@@ -72,6 +74,6 @@ component-node name=affine1_node component=affine1 input=Append(Offset(input, -4
 component-node name=nonlin1 component=relu1 input=affine1_node
 component-node name=final_affine component=final_affine input=nonlin1
 component-node name=output_nonlin component=logsoftmax input=final_affine
-output-node name=output input=output_nonlin  
+output-node name=output input=output_nonlin
 EOF
 */

--- a/src/xvectorbin/nnet3-xvector-compute.cc
+++ b/src/xvectorbin/nnet3-xvector-compute.cc
@@ -179,16 +179,18 @@ int main(int argc, char *argv[]) {
           for (int32 i = out_offset;
               i < std::min(out_offset + xvector_period, num_rows); i++)
             xvector_mat.Row(i).CopyFromVec(xvector);
-        } else
+        } else {
           xvector_mat.Row(chunk_indx).CopyFromVec(xvector);
+        }
       }
 
       // If output is a vector, scale it by the total weight.
       if (output_as_vector) {
         xvector_avg.Scale(1.0 / total_chunk_weight);
         vector_writer.Write(utt, xvector_avg);
-      } else
+      } else {
         matrix_writer.Write(utt, xvector_mat);
+      }
 
       frame_count += feats.NumRows();
       num_success++;


### PR DESCRIPTION
Adding a function in nnet3/nnet-utils.h for retrieving a constant output. Also adding a function that returns a string containing the eigenvalues of an output called 's' if it can be interpreted as a symmetric matrix.