### PR TITLE
Change filter type back to NCHW, since it supports more algos.

### DIFF
--- a/src/nnet3/convolution-cudnn-test.cc
+++ b/src/nnet3/convolution-cudnn-test.cc
@@ -36,7 +36,7 @@ static void GetRandomConfig(ConvolutionComputationConfig *config) {
   config->filter_stride_vertical = RandInt(1, 2);
   config->filter_stride_horizontal = RandInt(1, 2);
   config->filter_dilation_vertical = RandInt(1, 2);
-  config->filter_dilation_horizontal = 1;
+  config->filter_dilation_horizontal = RandInt(1, 2);
 
   config->input_image_height = RandInt(10, 20);
   config->input_image_width = RandInt(10, 20);

--- a/src/nnet3/convolution-cudnn.cc
+++ b/src/nnet3/convolution-cudnn.cc
@@ -181,11 +181,14 @@ void ConvolutionComputation::InitCudnn() {
   // relative to what the CUDNN interface specifies; this is because Kaldi's
   // notion of what is height vs. width is opposite to CUDNN's.  (There
   // are good reasons for this).
+  int in_dims[4] = {c.num_images, c.num_channels_in, c.input_image_width,
+		    c.input_image_height};
+  int in_stride[4] = {c.num_channels_in * c.input_image_width * c.input_image_height,
+		      c.input_image_width * c.input_image_height,
+		      c.input_image_height, 1};
   CUDNN_SAFE_CALL(
-      cudnnSetTensor4dDescriptor(input_desc_, CUDNN_TENSOR_NHWC,
-                                 CUDNN_DATA_BASEFLOAT, c.num_images,
-                                 c.num_channels_in, c.input_image_width,
-                                 c.input_image_height));
+      cudnnSetTensorNdDescriptor(input_desc_, CUDNN_DATA_BASEFLOAT, 4, in_dims,
+				 in_stride));
   // Again: width and height are swapped.
   CUDNN_SAFE_CALL(
       cudnnSetConvolution2dDescriptor(
@@ -228,11 +231,14 @@ void ConvolutionComputation::InitCudnn() {
 
   // These two member functions depend only on input_desc_,
   // conv_desc_, and params_desc_, so they are safe to call now.
+  int out_dims[4] = {c.num_images, c.num_channels_out, c.output_image_width,
+		     c.output_image_height};
+  int out_stride[4] = {c.num_channels_out * c.output_image_width * c.output_image_height,
+		       c.output_image_width * c.output_image_height,
+		       c.output_image_height, 1};
   CUDNN_SAFE_CALL(
-      cudnnSetTensor4dDescriptor(output_desc_, CUDNN_TENSOR_NHWC,
-                                 CUDNN_DATA_BASEFLOAT, c.num_images,
-                                 c.num_channels_out, kaldi_width_cudnn_height,
-                                 kaldi_height_cudnn_width));
+    cudnnSetTensorNdDescriptor(output_desc_, CUDNN_DATA_BASEFLOAT, 4, out_dims,
+			       out_stride));
 
   // We pad the bias with leading dims of 1, since CUDNN's tensors appear to
   // need a dimension of at least 3.


### PR DESCRIPTION
Convert assertion to warning, although I am not sure this works, since
if an algorithm fails to be found because of an out-of-memory error, it
is likely to fail at training time for the same reason.

This is the current error I am getting, after these changes, when I run `make -j convolution-cudnn-test && CUDNN_LOGINFO_DBG=1 CUDNN_LOGDEST_DBG=stderr ./convolution-cudnn-test 2 >&1  | tee`:

```
I! CuDNN (v7102) function cudnnGetConvolutionBackwardDataWorkspaceSize() called:
i!     handle: type=cudnnHandle_t; streamId=0x2;
i!     wDesc: type=cudnnFilterDescriptor_t:
i!         dataType: type=cudnnDataType_t; val=CUDNN_DATA_FLOAT (0);
i!         vect: type=int; val=0;
i!         nbDims: type=int; val=4;
i!         dimA: type=int; val=[2,9,1,2];
i!         format: type=cudnnTensorFormat_t; val=CUDNN_TENSOR_NCHW (0);
i!     dyDesc: type=cudnnTensorDescriptor_t:
i!         dataType: type=cudnnDataType_t; val=CUDNN_DATA_FLOAT (0);
i!         nbDims: type=int; val=4;
i!         dimA: type=int; val=[4,2,11,7];
i!         strideA: type=int; val=[154,1,14,2];
i!     convDesc: type=cudnnConvolutionDescriptor_t:
i!         mode: type=cudnnConvolutionMode_t; val=CUDNN_CROSS_CORRELATION (1);
i!         dataType: type=cudnnDataType_t; val=CUDNN_DATA_FLOAT (0);
i!         mathType: type=cudnnMathType_t; val=CUDNN_DEFAULT_MATH (0);
i!         arrayLength: type=int; val=2;
i!         padA: type=int; val=[1,1];
i!         strideA: type=int; val=[2,2];
i!         dilationA: type=int; val=[1,2];
i!         groupCount: type=int; val=1;
i!     dxDesc: type=cudnnTensorDescriptor_t:
i!         dataType: type=cudnnDataType_t; val=CUDNN_DATA_FLOAT (0);
i!         nbDims: type=int; val=4;
i!         dimA: type=int; val=[4,9,19,13];
i!         strideA: type=int; val=[2223,1,117,9];
i!     algo: type=cudnnConvolutionBwdDataAlgo_t; val=CUDNN_CONVOLUTION_BWD_DATA_ALGO_0 (0);
i! Time: 2018-10-23T03:18:18.896738 (0d+0h+0m+1s since start)
i! Process=6906; Thread=6906; Handle=0x557409815c20; StreamId=0x2.

ERROR ([5.5.97-b5d202]:ComputeTempSpaceSizes():convolution-cudnn.cc:339) cudnnStatus_t 9 : "CUDNN_STATUS_NOT_SUPPORTED" returned from 'cudnnGetConvolutionBackwardDataWorkspaceSize( CuDevice::Instantiate().GetCudnnHandle(), params_desc_, output_desc_, conv_desc_, input_desc_, bwd_data_algo_, &temp_space_required_backward_data_)'

[ Stack-Trace: ]
kaldi::MessageLogger::HandleMessage(kaldi::LogMessageEnvelope const&, char const*)
kaldi::FatalMessageLogger::~FatalMessageLogger()
kaldi::nnet3::cudnn_convolution::ConvolutionComputation::ComputeTempSpaceSizes()
kaldi::nnet3::cudnn_convolution::ConvolutionComputation::InitCudnn()
kaldi::nnet3::cudnn_convolution::ConvolutionComputation::ConvolutionComputation(kaldi::nnet3::cudnn_convolution::ConvolutionComputationConfig const&)
kaldi::nnet3::cudnn_convolution::TestConvolutionComputation()
main
__libc_start_main
_start

terminate called after throwing an instance of 'std::runtime_error'
  what():
```