### PR TITLE
More small fixes

### DIFF
--- a/egs/mini_librispeech/s5/local/chaina/tuning/run_tdnn_1a.sh
+++ b/egs/mini_librispeech/s5/local/chaina/tuning/run_tdnn_1a.sh
@@ -178,7 +178,7 @@ if [ $stage -le 14 ]; then
   # is not really a multilingual setup.
   # Note: the bottleneck dimension of 256 specified in the bottom.nnet must match
   # with the dimension of this transform (256).
-  cat <<EOF | nnet3-adapt --binary=false --num-classes=200 init - $tree_dir/tree.map $dir/0/default.ada
+  cat <<EOF | nnet3-adapt --binary=false init - $tree_dir/tree.map $dir/0/default.ada
 AppendTransform num-transforms=6
   NoOpTransform dim=64
   MeanOnlyTransform dim=64

--- a/src/adapt/differentiable-transform-itf.cc
+++ b/src/adapt/differentiable-transform-itf.cc
@@ -161,7 +161,7 @@ void DifferentiableTransformMapped::Write(std::ostream &os, bool binary) const {
 void DifferentiableTransformMapped::Check() const {
   KALDI_ASSERT(transform != NULL &&
                (pdf_map.empty() ||
-                *std::max_element(pdf_map.begin(), pdf_map.end()) + 1 ==
+                *std::max_element(pdf_map.begin(), pdf_map.end()) ==
                 transform->NumClasses()));
 }
 


### PR DESCRIPTION
This fixes the dim mismatch problem. Please take a look at the changes because I'm not sure this is the right fix.

Currently it runs up to stage 15 of run_tdnn_1a.sh but it can't go further because of this error (related to xconfigs of the top network):
```
ERROR:root:***Exception caught while parsing the following xconfig line:
***   tdnnf-layer name=tdnnf1 l2-regularize=0.03 dropout-proportion=0.0 bypass-scale=0.66 dim=768 bottleneck-dim=96 time-stride=1
...
File "steps/libs/nnet3/xconfig/utils.py", line 518, in replace_bracket_expressions_in_descriptor
    "invalid or out of range offset.".format(descriptor_string, fields[i]))
RuntimeError: Error tokenizing string '[-1]': expression [-1] has an invalid or out of range offset.
```

It seems like it's expecting an input layer for the first layer (tdnnf1).
