### PR TITLE
Construct SubMatrix/SubVector from numpy arrays without memcpy.

### DIFF
--- a/src/pybind/Makefile
+++ b/src/pybind/Makefile
@@ -3,7 +3,6 @@
 all:
 
 
-
 # Disable linking math libs because  not needed here.  Just for compilation speed.
 # no, it's now needed for context-fst-test.
 # MATHLIB = NONE
@@ -18,7 +17,9 @@ ifeq ($(KALDI_FLAVOR),static)
 endif
 
 PYBIND_INCLUDES=$(shell python3 -m pybind11 --includes)
+
 CXXFLAGS += $(PYBIND_INCLUDES)
+
 PYBIND_EXTENSION=$(shell python3-config --extension-suffix)
 LIBFILE=kaldi-pybind
 LIBFILE_EXTENSION=$(PYBIND_EXTENSION)
@@ -33,7 +34,10 @@ ifeq ($(shell uname),Darwin)
   LDFLAGS += -undefined dynamic_lookup
 endif
 
-CCFILES = kaldi_pybind.cc
+CCFILES = kaldi_pybind.cc \
+          matrix/matrix_common_pybind.cc matrix/matrix_pybind.cc \
+          matrix/vector_pybind.cc \
+          util/table_types_pybind.cc
 
 LIBNAME = kaldi_pybind
 
@@ -44,12 +48,25 @@ EXTRA_LDLIBS += $(foreach dep,$(ADDLIBS), $(dir $(dep))lib$(notdir $(basename $(
 
 LIBFILE=$(LIBNAME)$(LIBFILE_EXTENSION)
 
+.PHONY: all clean test
+
 all: $(LIBFILE)
 
-
-$(LIBFILE): $(ADDLIBS)
+$(LIBFILE): $(ADDLIBS) $(CCFILES)
 	$(CXX) $(CXXFLAGS) -shared -o $@ $(CCFILES) -Wl,--no-whole-archive -Wl,-rpath=$(CURDIR)/../lib $(LDFLAGS) $(LDLIBS) $(EXTRA_LDLIBS)
 	python3 -c 'import kaldi_pybind'  # this line is a test.
 
 clean:
 	-rm -f *.so
+	-rm -rf __pycache__
+
+test: all
+	./tests/test_kaldi_pybind.py
+	./tests/test_matrix.py
+
+# valgrind-python.supp is from http://svn.python.org/projects/python/trunk/Misc/valgrind-python.supp
+# since we do not compile Python from souce, we follow the comment in valgrind-python.supp
+# to uncomment suppressions for PyObject_Free and PyObject_Realloc.
+valgrind:
+	valgrind --tool=memcheck --suppressions=./valgrind-python.supp \
+   python3 -E -tt ./tests/test_matrix.py

--- a/src/pybind/kaldi_pybind.h
+++ b/src/pybind/kaldi_pybind.h
@@ -1,9 +1,9 @@
-// pybind/kaldi_pybind.cc
+// pybind/kaldi_pybind.h
 
 // Copyright 2019   Daniel Povey
 //           2019   Dongji Gao
 //           2019   Mobvoi AI Lab, Beijing, China (author: Fangjun Kuang)
-
+//
 // See ../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,24 +17,11 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
-#include "pybind/kaldi_pybind.h"
+#ifndef KALDI_PYBIND_KALDI_PYBIND_H_
+#define KALDI_PYBIND_KALDI_PYBIND_H_
 
-#include <string>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+namespace py = pybind11;
 
-#include "matrix/matrix_common_pybind.h"
-#include "matrix/matrix_pybind.h"
-#include "matrix/vector_pybind.h"
-#include "util/table_types_pybind.h"
-
-void pybind_matrix(py::module& m);
-PYBIND11_MODULE(kaldi_pybind, m) {
-  m.doc() =
-      "pybind11 binding of some things from kaldi's "
-      "src/matrix and src/util directories. "
-      "Source is in $(KALDI_ROOT)/src/pybind/kaldi_pybind.cc";
-
-  pybind_matrix_common(m);
-  pybind_matrix(m);
-  pybind_vector(m);
-  pybind_table_types(m);
-}
+#endif  // KALDI_PYBIND_KALDI_PYBIND_H_

--- a/src/pybind/matrix/matrix_common_pybind.cc
+++ b/src/pybind/matrix/matrix_common_pybind.cc
@@ -1,0 +1,43 @@
+// pybind/matrix/matrix_common_pybind.cc
+
+// Copyright 2019   Daniel Povey
+//           2019   Dongji Gao
+//           2019   Mobvoi AI Lab, Beijing, China (author: Fangjun Kuang)
+
+// See ../../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "matrix/matrix_common_pybind.h"
+
+#include "matrix/matrix-common.h"
+
+using namespace kaldi;
+
+void pybind_matrix_common(py::module& m) {
+  py::enum_<MatrixResizeType>(m, "MatrixResizeType", py::arithmetic(),
+                              "Matrix initialization policies")
+      .value("kSetZero", kSetZero, "Set to zero")
+      .value("kUndefined", kUndefined, "Leave undefined")
+      .value("kCopyData", kCopyData, "Copy any previously existing data")
+      .export_values();
+
+  py::enum_<MatrixStrideType>(m, "MatrixStrideType", py::arithmetic(),
+                              "Matrix stride policies")
+      .value("kDefaultStride", kDefaultStride,
+             "Set to a multiple of 16 in bytes")
+      .value("kStrideEqualNumCols", kStrideEqualNumCols,
+             "Set to the number of columns")
+      .export_values();
+}

--- a/src/pybind/matrix/matrix_common_pybind.h
+++ b/src/pybind/matrix/matrix_common_pybind.h
@@ -1,10 +1,10 @@
-// pybind/kaldi_pybind.cc
+// pybind/matrix/matrix_common_pybind.h
 
 // Copyright 2019   Daniel Povey
 //           2019   Dongji Gao
 //           2019   Mobvoi AI Lab, Beijing, China (author: Fangjun Kuang)
 
-// See ../../COPYING for clarification regarding multiple authors
+// See ../../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 //
@@ -17,24 +17,11 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef KALDI_PYBIND_MATRIX_MATRIX_COMMON_PYBIND_H_
+#define KALDI_PYBIND_MATRIX_MATRIX_COMMON_PYBIND_H_
+
 #include "pybind/kaldi_pybind.h"
 
-#include <string>
+void pybind_matrix_common(py::module& m);
 
-#include "matrix/matrix_common_pybind.h"
-#include "matrix/matrix_pybind.h"
-#include "matrix/vector_pybind.h"
-#include "util/table_types_pybind.h"
-
-void pybind_matrix(py::module& m);
-PYBIND11_MODULE(kaldi_pybind, m) {
-  m.doc() =
-      "pybind11 binding of some things from kaldi's "
-      "src/matrix and src/util directories. "
-      "Source is in $(KALDI_ROOT)/src/pybind/kaldi_pybind.cc";
-
-  pybind_matrix_common(m);
-  pybind_matrix(m);
-  pybind_vector(m);
-  pybind_table_types(m);
-}
+#endif  // KALDI_PYBIND_MATRIX_MATRIX_COMMON_PYBIND_H_

--- a/src/pybind/matrix/matrix_pybind.cc
+++ b/src/pybind/matrix/matrix_pybind.cc
@@ -1,0 +1,88 @@
+// pybind/matrix/matrix_pybind.cc
+
+// Copyright 2019   Daniel Povey
+//           2019   Dongji Gao
+//           2019   Mobvoi AI Lab, Beijing, China (author: Fangjun Kuang)
+
+// See ../../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "matrix/matrix_pybind.h"
+
+#include "matrix/kaldi-matrix.h"
+
+using namespace kaldi;
+
+void pybind_matrix(py::module& m) {
+  py::class_<MatrixBase<float>,
+             std::unique_ptr<MatrixBase<float>, py::nodelete>>(
+      m, "FloatMatrixBase",
+      "Base class which provides matrix operations not involving resizing\n"
+      "or allocation.   Classes Matrix and SubMatrix inherit from it and take "
+      "care of allocation and resizing.")
+      .def("NumRows", &MatrixBase<float>::NumRows, "Return number of rows")
+      .def("NumCols", &MatrixBase<float>::NumCols, "Return number of columns")
+      .def("Stride", &MatrixBase<float>::Stride, "Return stride")
+      .def("__repr__",
+           [](const MatrixBase<float>& b) -> std::string {
+             std::ostringstream str;
+             b.Write(str, false);
+             return str.str();
+           })
+      .def("__getitem__",
+           [](const MatrixBase<float>& m, std::pair<ssize_t, ssize_t> i) {
+             return m(i.first, i.second);
+           })
+      .def("__setitem__",
+           [](MatrixBase<float>& m, std::pair<ssize_t, ssize_t> i, float v) {
+             m(i.first, i.second) = v;
+           });
+
+  py::class_<Matrix<float>, MatrixBase<float>>(m, "FloatMatrix",
+                                               pybind11::buffer_protocol())
+      .def_buffer([](const Matrix<float>& m) -> pybind11::buffer_info {
+        return pybind11::buffer_info(
+            (void*)m.Data(),  // pointer to buffer
+            sizeof(float),    // size of one scalar
+            pybind11::format_descriptor<float>::format(),
+            2,                           // num-axes
+            {m.NumRows(), m.NumCols()},  // buffer dimensions
+            {sizeof(float) * m.Stride(),
+             sizeof(float)});  // stride for each index (in chars)
+      })
+      .def(py::init<const MatrixIndexT, const MatrixIndexT, MatrixResizeType,
+                    MatrixStrideType>(),
+           py::arg("row"), py::arg("col"), py::arg("resize_type") = kSetZero,
+           py::arg("stride_type") = kDefaultStride);
+
+  py::class_<SubMatrix<float>, MatrixBase<float>>(m, "FloatSubMatrix")
+      .def("__init__", [](SubMatrix<float>& m, py::buffer b) {
+        py::buffer_info info = b.request();
+        if (info.format != py::format_descriptor<float>::format()) {
+          KALDI_ERR << "Expected format: "
+                    << py::format_descriptor<float>::format() << "\n"
+                    << "Current format: " << info.format;
+        }
+        if (info.ndim != 2) {
+          KALDI_ERR << "Expected dim: 2\n"
+                    << "Current dim: " << info.ndim;
+        }
+
+        // numpy is row major by default, so we use strides[0]
+        new (&m)
+            SubMatrix<float>(reinterpret_cast<float*>(info.ptr), info.shape[0],
+                             info.shape[1], info.strides[0] / sizeof(float));
+      });
+}

--- a/src/pybind/matrix/matrix_pybind.h
+++ b/src/pybind/matrix/matrix_pybind.h
@@ -1,10 +1,10 @@
-// pybind/kaldi_pybind.cc
+// pybind/matrix/matrix_pybind.h
 
 // Copyright 2019   Daniel Povey
 //           2019   Dongji Gao
 //           2019   Mobvoi AI Lab, Beijing, China (author: Fangjun Kuang)
 
-// See ../../COPYING for clarification regarding multiple authors
+// See ../../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 //
@@ -17,24 +17,11 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef KALDI_PYBIND_MATRIX_MATRIX_PYBIND_H_
+#define KALDI_PYBIND_MATRIX_MATRIX_PYBIND_H_
+
 #include "pybind/kaldi_pybind.h"
 
-#include <string>
-
-#include "matrix/matrix_common_pybind.h"
-#include "matrix/matrix_pybind.h"
-#include "matrix/vector_pybind.h"
-#include "util/table_types_pybind.h"
-
 void pybind_matrix(py::module& m);
-PYBIND11_MODULE(kaldi_pybind, m) {
-  m.doc() =
-      "pybind11 binding of some things from kaldi's "
-      "src/matrix and src/util directories. "
-      "Source is in $(KALDI_ROOT)/src/pybind/kaldi_pybind.cc";
 
-  pybind_matrix_common(m);
-  pybind_matrix(m);
-  pybind_vector(m);
-  pybind_table_types(m);
-}
+#endif  // KALDI_PYBIND_MATRIX_MATRIX_PYBIND_H_

--- a/src/pybind/matrix/vector_pybind.cc
+++ b/src/pybind/matrix/vector_pybind.cc
@@ -1,0 +1,82 @@
+// pybind/matrix/vector_pybind.cc
+
+// Copyright 2019   Daniel Povey
+//           2019   Dongji Gao
+//           2019   Mobvoi AI Lab, Beijing, China (author: Fangjun Kuang)
+
+// See ../../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "matrix/vector_pybind.h"
+
+#include "matrix/kaldi-vector.h"
+
+using namespace kaldi;
+
+void pybind_vector(py::module& m) {
+  py::class_<VectorBase<float>,
+             std::unique_ptr<VectorBase<float>, py::nodelete>>(
+      m, "FloatVectorBase",
+      "Provides a vector abstraction class.\n"
+      "This class provides a way to work with vectors in kaldi.\n"
+      "It encapsulates basic operations and memory optimizations.")
+      .def("Read", &VectorBase<float>::Read,
+           "Reads from C++ stream (option to add to existing contents).\n"
+           "Throws exception on failure",
+           py::arg("in"), py::arg("binary"), py::arg("add") = false)
+      .def("Write", &VectorBase<float>::Write,
+           "Writes to C++ stream (option to write in binary).", py::arg("out"),
+           py::arg("binary"))
+      .def("Dim", &VectorBase<float>::Dim,
+           "Returns the  dimension of the vector.")
+      .def("__repr__",
+           [](const VectorBase<float>& a) -> std::string {
+             std::ostringstream str;
+             a.Write(str, false);
+             return str.str();
+           })
+      .def("__getitem__",
+           [](const VectorBase<float>& m, int i) { return m(i); })
+      .def("__setitem__",
+           [](VectorBase<float>& m, int i, float v) { m(i) = v; });
+
+  py::class_<Vector<float>, VectorBase<float>>(m, "FloatVector",
+                                               pybind11::buffer_protocol())
+      .def_buffer([](const Vector<float>& v) -> pybind11::buffer_info {
+        return pybind11::buffer_info(
+            (void*)v.Data(), sizeof(float),
+            pybind11::format_descriptor<float>::format(),
+            1,                // num-axes
+            {v.Dim()}, {4});  // strides (in chars)
+      })
+      .def(py::init<const MatrixIndexT, MatrixResizeType>(), py::arg("size"),
+           py::arg("resize_type") = kSetZero);
+
+  py::class_<SubVector<float>, VectorBase<float>>(m, "FloatSubVector")
+      .def("__init__", [](SubVector<float>& m, py::buffer b) {
+        py::buffer_info info = b.request();
+        if (info.format != py::format_descriptor<float>::format()) {
+          KALDI_ERR << "Expected format: "
+                    << py::format_descriptor<float>::format() << "\n"
+                    << "Current format: " << info.format;
+        }
+        if (info.ndim != 1) {
+          KALDI_ERR << "Expected dim: 1\n"
+                    << "Current dim: " << info.ndim;
+        }
+        new (&m)
+            SubVector<float>(reinterpret_cast<float*>(info.ptr), info.shape[0]);
+      });
+}

--- a/src/pybind/matrix/vector_pybind.h
+++ b/src/pybind/matrix/vector_pybind.h
@@ -1,10 +1,10 @@
-// pybind/kaldi_pybind.cc
+// pybind/matrix/vector_pybind.h
 
 // Copyright 2019   Daniel Povey
 //           2019   Dongji Gao
 //           2019   Mobvoi AI Lab, Beijing, China (author: Fangjun Kuang)
 
-// See ../../COPYING for clarification regarding multiple authors
+// See ../../../COPYING for clarification regarding multiple authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 //
@@ -17,24 +17,11 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef KALDI_PYBIND_MATRIX_VECTOR_PYBIND_H_
+#define KALDI_PYBIND_MATRIX_VECTOR_PYBIND_H_
+
 #include "pybind/kaldi_pybind.h"
 
-#include <string>
+void pybind_vector(py::module& m);
 
-#include "matrix/matrix_common_pybind.h"
-#include "matrix/matrix_pybind.h"
-#include "matrix/vector_pybind.h"
-#include "util/table_types_pybind.h"
-
-void pybind_matrix(py::module& m);
-PYBIND11_MODULE(kaldi_pybind, m) {
-  m.doc() =
-      "pybind11 binding of some things from kaldi's "
-      "src/matrix and src/util directories. "
-      "Source is in $(KALDI_ROOT)/src/pybind/kaldi_pybind.cc";
-
-  pybind_matrix_common(m);
-  pybind_matrix(m);
-  pybind_vector(m);
-  pybind_table_types(m);
-}
+#endif  // KALDI_PYBIND_MATRIX_VECTOR_PYBIND_H_

--- a/src/pybind/tests/test_kaldi_pybind.py
+++ b/src/pybind/tests/test_kaldi_pybind.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import unittest
 import numpy as np
 import os

--- a/src/pybind/tests/test_matrix.py
+++ b/src/pybind/tests/test_matrix.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Mobvoi AI Lab, Beijing, China (author: Fangjun Kuang)
+# Apache 2.0
+
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
+
+import unittest
+
+import numpy as np
+
+import kaldi
+
+
+class TestFloatSubVecotr(unittest.TestCase):
+
+    def test_from_numpy(self):
+        num_data = 10
+        data = np.arange(num_data).astype(np.float32)
+        v = kaldi.FloatSubVector(data)
+        self.assertEqual(v.Dim(), num_data)
+        for i in range(num_data):
+            self.assertEqual(i, v[i])
+
+        # memory is shared between numpy array and FloatSubVector
+        for i in range(num_data):
+            v[i] += 10
+            self.assertEqual(data[i], i + 10)
+
+
+class TestFloatSubMatrix(unittest.TestCase):
+
+    def test_from_numpy(self):
+        num_rows = 5
+        num_cols = 6
+        data = np.arange(num_rows * num_cols).reshape(
+            num_rows, num_cols).astype(np.float32)
+        m = kaldi.FloatSubMatrix(data)
+        self.assertEqual(m.NumRows(), num_rows)
+        self.assertEqual(m.NumCols(), num_cols)
+        self.assertEqual(m.Stride(), data.strides[0] / 4)
+        for r in range(num_rows):
+            for c in range(num_cols):
+                self.assertEqual(m[r, c], data[r, c])
+
+        # memory is shared between numpy array and FloatSubMatrix
+        for r in range(num_rows):
+            for c in range(num_cols):
+                m[r, c] += 10
+                self.assertEqual(m[r, c], data[r, c])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/pybind/util/table_types_pybind.cc
+++ b/src/pybind/util/table_types_pybind.cc
@@ -1,0 +1,84 @@
+// pybind/util/table_types_pybind.cc
+
+// Copyright 2019   Daniel Povey
+//           2019   Dongji Gao
+//           2019   Mobvoi AI Lab, Beijing, China (author: Fangjun Kuang)
+
+// See ../../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/table_types_pybind.h"
+
+#include "util/table-types.h"
+
+#include "util/kaldi-table-inl.h"
+
+using namespace kaldi;
+
+namespace {
+
+template <class Holder>
+void sequential_matrix_reader(py::module& m, const std::string& data_type) {
+  std::string name = "SequentialBaseFloat" + data_type + "Reader";
+  py::class_<SequentialTableReader<Holder>>(m, name.c_str())
+      .def(py::init<>())
+      .def(py::init<const std::string&>())
+      .def("Open", &SequentialTableReader<Holder>::Open)
+      .def("Done", &SequentialTableReader<Holder>::Done)
+      .def("Key", &SequentialTableReader<Holder>::Key)
+      .def("FreeCurrent", &SequentialTableReader<Holder>::FreeCurrent)
+      .def("Value", &SequentialTableReader<Holder>::Value)
+      .def("Next", &SequentialTableReader<Holder>::Next)
+      .def("IsOpen", &SequentialTableReader<Holder>::IsOpen)
+      .def("Close", &SequentialTableReader<Holder>::Close);
+}
+
+template <class Holder>
+void random_access_matrix_reader(py::module& m, const std::string& data_type) {
+  std::string name = "RandomAccessBaseFloat" + data_type + "Reader";
+  py::class_<RandomAccessTableReader<Holder>>(m, name.c_str())
+      .def(py::init<>())
+      .def(py::init<const std::string&>())
+      .def("Open", &RandomAccessTableReader<Holder>::Open)
+      .def("IsOpen", &RandomAccessTableReader<Holder>::IsOpen)
+      .def("Close", &RandomAccessTableReader<Holder>::Close)
+      .def("HasKey", &RandomAccessTableReader<Holder>::HasKey)
+      .def("Value", &RandomAccessTableReader<Holder>::Value);
+}
+
+template <class Holder>
+void matrix_writer(py::module& m, const std::string& data_type) {
+  std::string name = "BaseFloat" + data_type + "Writer";
+  py::class_<TableWriter<Holder>>(m, name.c_str())
+      .def(py::init<const std::string&>())
+      .def("IsOpen", &TableWriter<Holder>::IsOpen)
+      .def("Open", &TableWriter<Holder>::Open)
+      .def("Write", &TableWriter<Holder>::Write)
+      .def("Flush", &TableWriter<Holder>::Flush)
+      .def("Close", &TableWriter<Holder>::Close);
+}
+
+}  // namespace
+
+void pybind_table_types(py::module& m) {
+  sequential_matrix_reader<KaldiObjectHolder<Matrix<float>>>(m, "Matrix");
+  sequential_matrix_reader<KaldiObjectHolder<Vector<float>>>(m, "Vector");
+
+  random_access_matrix_reader<KaldiObjectHolder<Matrix<float>>>(m, "Matrix");
+  random_access_matrix_reader<KaldiObjectHolder<Vector<float>>>(m, "Vector");
+
+  matrix_writer<KaldiObjectHolder<Matrix<float>>>(m, "Matrix");
+  matrix_writer<KaldiObjectHolder<Vector<float>>>(m, "Vector");
+}

--- a/src/pybind/util/table_types_pybind.h
+++ b/src/pybind/util/table_types_pybind.h
@@ -1,4 +1,4 @@
-// pybind/kaldi_pybind.cc
+// pybind/util/table_types_pybind.h
 
 // Copyright 2019   Daniel Povey
 //           2019   Dongji Gao
@@ -17,24 +17,11 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef KALDI_PYBIND_UTIL_TABLE_TYPES_PYBIND_H_
+#define KALDI_PYBIND_UTIL_TABLE_TYPES_PYBIND_H_
+
 #include "pybind/kaldi_pybind.h"
 
-#include <string>
+void pybind_table_types(py::module& m);
 
-#include "matrix/matrix_common_pybind.h"
-#include "matrix/matrix_pybind.h"
-#include "matrix/vector_pybind.h"
-#include "util/table_types_pybind.h"
-
-void pybind_matrix(py::module& m);
-PYBIND11_MODULE(kaldi_pybind, m) {
-  m.doc() =
-      "pybind11 binding of some things from kaldi's "
-      "src/matrix and src/util directories. "
-      "Source is in $(KALDI_ROOT)/src/pybind/kaldi_pybind.cc";
-
-  pybind_matrix_common(m);
-  pybind_matrix(m);
-  pybind_vector(m);
-  pybind_table_types(m);
-}
+#endif  // KALDI_PYBIND_UTIL_TABLE_TYPES_PYBIND_H_

--- a/src/pybind/valgrind-python.supp
+++ b/src/pybind/valgrind-python.supp
@@ -1,0 +1,391 @@
+#
+# This is a valgrind suppression file that should be used when using valgrind.
+#
+#  Here's an example of running valgrind:
+#
+#	cd python/dist/src
+#	valgrind --tool=memcheck --suppressions=Misc/valgrind-python.supp \
+#		./python -E -tt ./Lib/test/regrtest.py -u bsddb,network
+#
+# You must edit Objects/obmalloc.c and uncomment Py_USING_MEMORY_DEBUGGER
+# to use the preferred suppressions with Py_ADDRESS_IN_RANGE.
+#
+# If you do not want to recompile Python, you can uncomment
+# suppressions for PyObject_Free and PyObject_Realloc.
+#
+# See Misc/README.valgrind for more information.
+
+# all tool names: Addrcheck,Memcheck,cachegrind,helgrind,massif
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Addr4
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Value4
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 8 (x86_64 aka amd64)
+   Memcheck:Value8
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+{
+   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+   Memcheck:Cond
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+#
+# Leaks (including possible leaks)
+#    Hmmm, I wonder if this masks some real leaks.  I think it does.
+#    Will need to fix that.
+#
+
+{
+   Suppress leaking the GIL.  Happens once per process, see comment in ceval.c.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_allocate_lock
+   fun:PyEval_InitThreads
+}
+
+{
+   Suppress leaking the GIL after a fork.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_allocate_lock
+   fun:PyEval_ReInitThreads
+}
+
+{
+   Suppress leaking the autoTLSkey.  This looks like it shouldn't leak though.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_create_key
+   fun:_PyGILState_Init
+   fun:Py_InitializeEx
+   fun:Py_Main
+}
+
+{
+   Hmmm, is this a real leak or like the GIL?
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_ReInitTLS
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:realloc
+   fun:_PyObject_GC_Resize
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_New
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_NewVar
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+#
+# Non-python specific leaks
+#
+
+{
+   Handle pthread issue (possibly leaked)
+   Memcheck:Leak
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls_storage
+   fun:_dl_allocate_tls
+}
+
+{
+   Handle pthread issue (possibly leaked)
+   Memcheck:Leak
+   fun:memalign
+   fun:_dl_allocate_tls_storage
+   fun:_dl_allocate_tls
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Addr4
+   fun:PyObject_Free
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Value4
+   fun:PyObject_Free
+}
+
+{
+   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+   Memcheck:Cond
+   fun:PyObject_Free
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Addr4
+   fun:PyObject_Realloc
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Value4
+   fun:PyObject_Realloc
+}
+
+{
+   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+   Memcheck:Cond
+   fun:PyObject_Realloc
+}
+
+###
+### All the suppressions below are for errors that occur within libraries
+### that Python uses.  The problems to not appear to be related to Python's
+### use of the libraries.
+###
+
+{
+   Generic ubuntu ld problems
+   Memcheck:Addr8
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+}
+
+{
+   Generic gentoo ld problems
+   Memcheck:Cond
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Param
+   write(buf)
+   fun:write
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_close
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Value8
+   fun:memmove
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Cond
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Cond
+   fun:memmove
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   GDBM problems, see test_gdbm
+   Memcheck:Param
+   write(buf)
+   fun:write
+   fun:gdbm_open
+
+}
+
+{
+   ZLIB problems, see test_gzip
+   Memcheck:Cond
+   obj:/lib/libz.so.1.2.3
+   obj:/lib/libz.so.1.2.3
+   fun:deflate
+}
+
+{
+   Avoid problems w/readline doing a putenv and leaking on exit
+   Memcheck:Leak
+   fun:malloc
+   fun:xmalloc
+   fun:sh_set_lines_and_columns
+   fun:_rl_get_screen_size
+   fun:_rl_init_terminal_io
+   obj:/lib/libreadline.so.4.3
+   fun:rl_initialize
+}
+
+###
+### These occur from somewhere within the SSL, when running
+###  test_socket_sll.  They are too general to leave on by default.
+###
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Cond
+###   fun:memset
+###}
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Value4
+###   fun:memset
+###}
+###
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Cond
+###   fun:MD5_Update
+###}
+###
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Value4
+###   fun:MD5_Update
+###}
+
+#
+# All of these problems come from using test_socket_ssl
+#
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_bin2bn
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_num_bits_word
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:BN_num_bits_word
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_mod_exp_mont_word
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_mod_exp_mont
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Param
+   write(buf)
+   fun:write
+   obj:/usr/lib/libcrypto.so.0.9.7
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:RSA_verify
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:RSA_verify
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:DES_set_key_unchecked
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:DES_encrypt2
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   obj:/usr/lib/libssl.so.0.9.7
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   obj:/usr/lib/libssl.so.0.9.7
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BUF_MEM_grow_clean
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:memcpy
+   fun:ssl3_read_bytes
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:SHA1_Update
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:SHA1_Update
+}
+
+


### PR DESCRIPTION
In addition, refactor kaldi pybind to be more modular.

It turns out that there is no way to construct a `Vector<float>` or `Matrix<float>` from a numpy
without data copy since `Vector<float>` and `Matrix<float>` take ownership of the memory and
will free it in their destructors.