### PR TITLE
Add support to zero-copy Kaldi CuVector/CuMatrix to PyTorch's GPU tensor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,9 @@
 !/src/doc/*
 !/src/*/Makefile
 !/src/*/README
+!/src/pybind/*
 
-# Compiled Object files and python ciles
+# Compiled Object files and python files
 *.slo
 *.lo
 *.o

--- a/src/cudamatrix/cu-device.h
+++ b/src/cudamatrix/cu-device.h
@@ -90,6 +90,10 @@ class CuDevice {
     return ans;
   }
 
+  static inline int32 GetCurrentDeviceId() {
+    return device_id_;
+  }
+
   inline cublasHandle_t GetCublasHandle() { return cublas_handle_; }
   inline cusparseHandle_t GetCusparseHandle() { return cusparse_handle_; }
   inline curandGenerator_t GetCurandHandle() { return curand_handle_; }

--- a/src/pybind/Makefile
+++ b/src/pybind/Makefile
@@ -41,6 +41,7 @@ cudamatrix/cu_device_pybind.cc \
 cudamatrix/cu_matrix_pybind.cc \
 cudamatrix/cu_vector_pybind.cc \
 cudamatrix/cudamatrix_pybind.cc \
+dlpack/dlpack_deleter.cc \
 dlpack/dlpack_pybind.cc \
 feat/feat_pybind.cc \
 feat/feature_pybind.cc \

--- a/src/pybind/Makefile
+++ b/src/pybind/Makefile
@@ -43,6 +43,8 @@ cudamatrix/cu_vector_pybind.cc \
 cudamatrix/cudamatrix_pybind.cc \
 dlpack/dlpack_deleter.cc \
 dlpack/dlpack_pybind.cc \
+dlpack/dlpack_submatrix.cc \
+dlpack/dlpack_subvector.cc \
 feat/feat_pybind.cc \
 feat/feature_pybind.cc \
 feat/online_feature_pybind.cc \
@@ -62,6 +64,7 @@ nnet3/nnet3_pybind.cc \
 nnet3/nnet_chain_example_pybind.cc \
 nnet3/nnet_common_pybind.cc \
 nnet3/nnet_example_pybind.cc \
+tests/test_dlpack_subvector.cc \
 util/table_types_pybind.cc
 
 CCFILES_OBJS := $(CCFILES:%.cc=%.o)
@@ -106,6 +109,7 @@ clean:
 	-rm -f .depend.mk
 
 test: all
+	python3 tests/test_dlpack_subvector.py
 	python3 tests/test_kaldi_pybind.py
 	make -C chain test
 	make -C cudamatrix test

--- a/src/pybind/Makefile
+++ b/src/pybind/Makefile
@@ -125,7 +125,8 @@ valgrind:
 depend:
 	rm -f .depend.mk
 	for f in $(CCFILES); do \
-    $(CXX) -M -MT "$$(dirname $$f)/$$(basename -s .cc $$f).o" $(CXXFLAGS) $$f >> .depend.mk; \
+        $(CXX) -M -MT "$$(dirname $$f)/$$(basename -s .cc $$f).o" \
+          $(CXXFLAGS) $$f >> .depend.mk; \
   done
 
 -include .depend.mk

--- a/src/pybind/Makefile
+++ b/src/pybind/Makefile
@@ -44,6 +44,7 @@ cudamatrix/cudamatrix_pybind.cc \
 dlpack/dlpack_pybind.cc \
 feat/feat_pybind.cc \
 feat/feature_pybind.cc \
+feat/online_feature_pybind.cc \
 feat/wave_reader_pybind.cc \
 fst/arc_pybind.cc \
 fst/compile_pybind.cc \

--- a/src/pybind/cudamatrix/cu_device_pybind.cc
+++ b/src/pybind/cudamatrix/cu_device_pybind.cc
@@ -20,6 +20,7 @@
 
 #include "cudamatrix/cu_device_pybind.h"
 
+#include "base/kaldi-error.h"
 #include "cudamatrix/cu-device.h"
 
 using namespace kaldi;
@@ -30,7 +31,7 @@ void pybind_cu_device(py::module& m) {
 #if HAVE_CUDA == 1
           CuDevice::Instantiate().SelectGpuDevice(device_id);
 #else
-          KALDI_LOG << "Kaldi is NOT compiled with GPU! Ingore it.";
+          KALDI_LOG << "Kaldi is NOT compiled with GPU! Ignore it.";
 #endif
         },
         py::arg("device_id"));

--- a/src/pybind/cudamatrix/cu_device_pybind_test.py
+++ b/src/pybind/cudamatrix/cu_device_pybind_test.py
@@ -9,8 +9,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
 
 import unittest
 
-import numpy as np
-
 import kaldi
 
 

--- a/src/pybind/cudamatrix/cu_matrix_pybind.cc
+++ b/src/pybind/cudamatrix/cu_matrix_pybind.cc
@@ -42,11 +42,7 @@ void pybind_cu_matrix(py::module& m) {
         .def("__getitem__",
              [](const PyClass& m, std::pair<ssize_t, ssize_t> i) {
                return m(i.first, i.second);
-             })
-        .def("to_dlpack", [](PyClass* m) {
-          // we use the name `to_dlpack` because PyTorch uses the same name
-          return CuMatrixToDLPack(m);
-        });
+             });
   }
 
   {
@@ -59,7 +55,11 @@ void pybind_cu_matrix(py::module& m) {
              py::arg("resize_type") = kSetZero,
              py::arg("MatrixStrideType") = kDefaultStride)
         .def(py::init<const MatrixBase<float>&, MatrixTransposeType>(),
-             py::arg("other"), py::arg("trans") = kNoTrans);
+             py::arg("other"), py::arg("trans") = kNoTrans)
+        .def("to_dlpack", [](PyClass* m) {
+          // we use the name `to_dlpack` because PyTorch uses the same name
+          return CuMatrixToDLPack(m);
+        });
     // TODO(fangjun): wrap other methods when needed
   }
   {

--- a/src/pybind/cudamatrix/cu_matrix_pybind.cc
+++ b/src/pybind/cudamatrix/cu_matrix_pybind.cc
@@ -43,53 +43,56 @@ void pybind_cu_matrix(py::module& m) {
              [](const PyClass& m, std::pair<ssize_t, ssize_t> i) {
                return m(i.first, i.second);
              })
+        .def("to_dlpack", [](PyClass* m) {
 #if HAVE_CUDA == 1
-        .def("to_dlpack",
-             [](PyClass* m) {
-               // we use the name `to_dlpack` because PyTorch uses the same name
+          // we use the name `to_dlpack` because PyTorch uses the same name
 
-               // the created `managed_tensor` will be freed in
-               // `DLManagedTensorDeleter`, so no memory leak here
-               auto* managed_tensor = new DLManagedTensor();
-               managed_tensor->manager_ctx = nullptr;
+          // the created `managed_tensor` will be freed in
+          // `DLManagedTensorDeleter`, which does not free `data`,
+          // so no memory leak here
+          auto* managed_tensor = new DLManagedTensor();
+          managed_tensor->manager_ctx = nullptr;
 
-               // setup the deleter to free allocated memory.
-               // refer to
-               // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L361
-               // for how and when the deleter is invoked.
-               managed_tensor->deleter = &DLManagedTensorDeleter;
+          // setup the deleter to free allocated memory.
+          // refer to
+          // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L361
+          // for how and when the deleter is invoked.
+          managed_tensor->deleter = &DLManagedTensorDeleter;
 
-               auto* tensor = &managed_tensor->dl_tensor;
-               tensor->data = m->Data();
-               tensor->ctx.device_type = kDLGPU;
-               tensor->ctx.device_id = CuDevice::GetCurrentDeviceId();
+          auto* tensor = &managed_tensor->dl_tensor;
+          tensor->data = m->Data();
+          tensor->ctx.device_type = kDLGPU;
+          tensor->ctx.device_id = CuDevice::GetCurrentDeviceId();
 
-               tensor->ndim = 2;
+          tensor->ndim = 2;
 
-               tensor->dtype.code = kDLFloat;
-               tensor->dtype.bits = 32;  // single precision float
-               tensor->dtype.lanes = 1;
+          tensor->dtype.code = kDLFloat;
+          tensor->dtype.bits = 32;  // single precision float
+          tensor->dtype.lanes = 1;
 
-               // `shape` and `strides` are freed in `DLManagedTensorDeleter`,
-               // so no memory leak here
-               tensor->shape = new int64_t[2];
-               tensor->shape[0] = m->NumRows();
-               tensor->shape[1] = m->NumCols();
+          // `shape` and `strides` are freed in `DLManagedTensorDeleter`,
+          // so no memory leak here
+          tensor->shape = new int64_t[2];
+          tensor->shape[0] = m->NumRows();
+          tensor->shape[1] = m->NumCols();
 
-               tensor->strides = new int64_t[2];
-               tensor->strides[0] = m->Stride();
-               tensor->strides[1] = 1;
-               tensor->byte_offset = 0;
+          tensor->strides = new int64_t[2];
+          tensor->strides[0] = m->Stride();
+          tensor->strides[1] = 1;
+          tensor->byte_offset = 0;
 
-               // WARNING(fangjun): the name of the capsule MUST be `dltensor`
-               // for PyTorch; refer to
-               // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L383/
-               // for more details.
-               return py::capsule(managed_tensor, "dltensor");
-             })
+          // WARNING(fangjun): the name of the capsule MUST be `dltensor`
+          // for PyTorch; refer to
+          // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L383/
+          // for more details.
+          return py::capsule(managed_tensor, "dltensor");
+#else
+          KALDI_ERR << "Kaldi is not compiled with GPU!";
+          return py::none();
 #endif
-        ;
+        });
   }
+
   {
     using PyClass = CuMatrix<float>;
     py::class_<PyClass, CuMatrixBase<float>>(m, "FloatCuMatrix")
@@ -105,6 +108,33 @@ void pybind_cu_matrix(py::module& m) {
   }
   {
     using PyClass = CuSubMatrix<float>;
-    py::class_<PyClass, CuMatrixBase<float>>(m, "FloatCuSubMatrix");
+    py::class_<PyClass, CuMatrixBase<float>>(m, "FloatCuSubMatrix")
+        .def("from_dlpack", [](py::capsule* capsule) {
+#if HAVE_CUDA == 1
+          DLManagedTensor* managed_tensor = *capsule;
+
+          auto* tensor = &managed_tensor->dl_tensor;
+
+          // we support only 2-D tensor
+          KALDI_ASSERT(tensor->ndim == 2);
+
+          // we support only float (single precision, 32-bit) tensor
+          KALDI_ASSERT(tensor->dtype.code == kDLFloat);
+          KALDI_ASSERT(tensor->dtype.bits == 32);
+          KALDI_ASSERT(tensor->dtype.lanes == 1);
+
+          auto* ctx = &tensor->ctx;
+          KALDI_ASSERT(ctx->device_type == kDLGPU);
+          KALDI_ASSERT(ctx->device_id == CuDevice::GetCurrentDeviceId());
+
+          // DLPack assumes row major, so we use strides[0]
+          return CuSubMatrix<float>(reinterpret_cast<float*>(tensor->data),
+                                    tensor->shape[0], tensor->shape[1],
+                                    tensor->strides[0]);
+#else
+          KALDI_ERR << "Kaldi is not compiled with GPU!";
+          return py::none();
+#endif
+        });
   }
 }

--- a/src/pybind/cudamatrix/cu_vector_pybind.cc
+++ b/src/pybind/cudamatrix/cu_vector_pybind.cc
@@ -36,11 +36,7 @@ void pybind_cu_vector(py::module& m) {
         .def("Set", &PyClass::Set, py::arg("value"))
         .def("Add", &PyClass::Add, py::arg("value"))
         .def("Scale", &PyClass::Scale, py::arg("value"))
-        .def("__getitem__", [](const PyClass& v, int i) { return v(i); })
-        .def("to_dlpack", [](PyClass* v) {
-          // we use the name `to_dlpack` because PyTorch uses the same name
-          return CuVectorToDLPack(v);
-        });
+        .def("__getitem__", [](const PyClass& v, int i) { return v(i); });
   }
   {
     using PyClass = CuVector<float>;
@@ -48,7 +44,11 @@ void pybind_cu_vector(py::module& m) {
         .def(py::init<>())
         .def(py::init<MatrixIndexT, MatrixResizeType>(), py::arg("dim"),
              py::arg("MatrixResizeType") = kSetZero)
-        .def(py::init<const VectorBase<float>&>(), py::arg("v"));
+        .def(py::init<const VectorBase<float>&>(), py::arg("v"))
+        .def("to_dlpack", [](PyClass* v) {
+          // we use the name `to_dlpack` because PyTorch uses the same name
+          return CuVectorToDLPack(v);
+        });
     // TODO(fangjun): wrap other methods when needed
   }
   {

--- a/src/pybind/cudamatrix/cu_vector_pybind.cc
+++ b/src/pybind/cudamatrix/cu_vector_pybind.cc
@@ -21,6 +21,7 @@
 #include "cudamatrix/cu_vector_pybind.h"
 
 #include "cudamatrix/cu-vector.h"
+#include "dlpack/dlpack_deleter.h"
 
 using namespace kaldi;
 
@@ -34,9 +35,62 @@ void pybind_cu_vector(py::module& m) {
         .def("SetZero", &PyClass::SetZero)
         .def("Set", &PyClass::Set, py::arg("value"))
         .def("Add", &PyClass::Add, py::arg("value"))
-        .def("Scale", &PyClass::Scale, py::arg("value"));
+        .def("Scale", &PyClass::Scale, py::arg("value"))
+        .def("__getitem__", [](const PyClass& v, int i) { return v(i); })
+#if HAVE_CUDA == 1
+        .def("to_dlpack",
+             [](PyClass* v) {
+               // we use the name `to_dlpack` because PyTorch uses the same name
+
+               // the created `managed_tensor` will be freed in
+               // `DLManagedTensorDeleter`, so no memory leak here.
+               auto* managed_tensor = new DLManagedTensor();
+               managed_tensor->manager_ctx = nullptr;
+
+               // setup the deleter to free allocated memory.
+               // refer to
+               // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L361
+               // for how and when the deleter is invoked.
+               managed_tensor->deleter = &DLManagedTensorDeleter;
+
+               auto* tensor = &managed_tensor->dl_tensor;
+               tensor->data = v->Data();
+               tensor->ctx.device_type = kDLGPU;
+               tensor->ctx.device_id = CuDevice::GetCurrentDeviceId();
+
+               tensor->ndim = 1;
+
+               tensor->dtype.code = kDLFloat;
+               tensor->dtype.bits = 32;  // single precision float
+               tensor->dtype.lanes = 1;
+
+               // `shape` and `strides` are freed in `DLManagedTensorDeleter`,
+               // so no memory leak here.
+               tensor->shape = new int64_t[1];
+               tensor->shape[0] = v->Dim();
+
+               tensor->strides = new int64_t[1];
+               tensor->strides[0] = 1;
+               tensor->byte_offset = 0;
+
+               // WARNING(fangjun): the name of the capsule MUST be `dltensor`
+               // for PyTorch; refer to
+               // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L383/
+               // for more details
+               return py::capsule(managed_tensor, "dltensor");
+             })
+#endif
+        ;
   }
-  // TODO(fangjun): add wrapper for CuVector
+  {
+    using PyClass = CuVector<float>;
+    py::class_<PyClass, CuVectorBase<float>>(m, "FloatCuVector")
+        .def(py::init<>())
+        .def(py::init<MatrixIndexT, MatrixResizeType>(), py::arg("dim"),
+             py::arg("MatrixResizeType") = kSetZero)
+        .def(py::init<const VectorBase<float>&>(), py::arg("v"));
+    // TODO(fangjun): wrap other methods when needed
+  }
   {
     using PyClass = CuSubVector<float>;
     py::class_<PyClass, CuVectorBase<float>>(m, "FloatCuSubVector");

--- a/src/pybind/cudamatrix/cu_vector_pybind.cc
+++ b/src/pybind/cudamatrix/cu_vector_pybind.cc
@@ -21,7 +21,7 @@
 #include "cudamatrix/cu_vector_pybind.h"
 
 #include "cudamatrix/cu-vector.h"
-#include "dlpack/dlpack_deleter.h"
+#include "dlpack/dlpack_pybind.h"
 
 using namespace kaldi;
 
@@ -38,50 +38,8 @@ void pybind_cu_vector(py::module& m) {
         .def("Scale", &PyClass::Scale, py::arg("value"))
         .def("__getitem__", [](const PyClass& v, int i) { return v(i); })
         .def("to_dlpack", [](PyClass* v) {
-#if HAVE_CUDA == 1
           // we use the name `to_dlpack` because PyTorch uses the same name
-
-          // the created `managed_tensor` will be freed in
-          // `DLManagedTensorDeleter`, which does not free `data`,
-          // so no memory leak here
-          auto* managed_tensor = new DLManagedTensor();
-          managed_tensor->manager_ctx = nullptr;
-
-          // setup the deleter to free allocated memory.
-          // refer to
-          // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L361
-          // for how and when the deleter is invoked.
-          managed_tensor->deleter = &DLManagedTensorDeleter;
-
-          auto* tensor = &managed_tensor->dl_tensor;
-          tensor->data = v->Data();
-          tensor->ctx.device_type = kDLGPU;
-          tensor->ctx.device_id = CuDevice::GetCurrentDeviceId();
-
-          tensor->ndim = 1;
-
-          tensor->dtype.code = kDLFloat;
-          tensor->dtype.bits = 32;  // single precision float
-          tensor->dtype.lanes = 1;
-
-          // `shape` and `strides` are freed in `DLManagedTensorDeleter`,
-          // so no memory leak here.
-          tensor->shape = new int64_t[1];
-          tensor->shape[0] = v->Dim();
-
-          tensor->strides = new int64_t[1];
-          tensor->strides[0] = 1;
-          tensor->byte_offset = 0;
-
-          // WARNING(fangjun): the name of the capsule MUST be `dltensor`
-          // for PyTorch; refer to
-          // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L383/
-          // for more details
-          return py::capsule(managed_tensor, "dltensor");
-#else
-          KALDI_ERR << "Kaldi is not compiled with GPU!";
-          return py::none();
-#endif
+          return CuVectorToDLPack(v);
         });
   }
   {
@@ -95,31 +53,12 @@ void pybind_cu_vector(py::module& m) {
   }
   {
     using PyClass = CuSubVector<float>;
-    py::class_<PyClass, CuVectorBase<float>>(m, "FloatCuSubVector")
-        .def("from_dlpack", [](py::capsule* capsule) {
-#if HAVE_CUDA == 1
-          DLManagedTensor* managed_tensor = *capsule;
-
-          auto* tensor = &managed_tensor->dl_tensor;
-
-          // we support only 1-D tensor
-          KALDI_ASSERT(tensor->ndim == 1);
-
-          // we support only float (single precision, 32-bit) tensor
-          KALDI_ASSERT(tensor->dtype.code == kDLFloat);
-          KALDI_ASSERT(tensor->dtype.bits == 32);
-          KALDI_ASSERT(tensor->dtype.lanes == 1);
-
-          auto* ctx = &tensor->ctx;
-          KALDI_ASSERT(ctx->device_type == kDLGPU);
-          KALDI_ASSERT(ctx->device_id == CuDevice::GetCurrentDeviceId());
-
-          return CuSubVector<float>(reinterpret_cast<float*>(tensor->data),
-                                    tensor->shape[0]);
-#else
-          KALDI_ERR << "Kaldi is not compiled with GPU!";
-          return py::none();
-#endif
-        });
+    py::class_<PyClass, CuVectorBase<float>>(m, "FloatCuSubVector");
   }
+  py::class_<DLPackCuSubVector<float>, CuSubVector<float>>(
+      m, "DLPackFloatCuSubVector")
+      .def("from_dlpack",
+           [](py::capsule* capsule) { return CuSubVectorFromDLPack(capsule); },
+           py::return_value_policy::take_ownership);
+  // no need to wrap the constructor as the user is NOT supposed to invoke it.
 }

--- a/src/pybind/dlpack/dlpack_deleter.cc
+++ b/src/pybind/dlpack/dlpack_deleter.cc
@@ -17,8 +17,42 @@
 // limitations under the License.
 
 #include "dlpack/dlpack_deleter.h"
+#include <iostream>
 
 namespace kaldi {
+
+/*
+ * To check that the deleter is indeed called by the consumer of the PyCapsule,
+ * you can print a log message inside this deleter.
+ *
+ * Take PyTorch as an example, for the following test Python code
+
+```python
+from torch.utils.dlpack import from_dlpack
+import kaldi
+
+v = kaldi.FloatVector(3)
+
+tensor = from_dlpack(v.to_dlpack())
+print('begin to delete tensor')
+del tensor
+print('you should see the deleter has been called')
+```
+
+If you put:
+```cpp
+  std::cout << "deleter is called!" << std::endl;
+```
+inside the following function, you should see the following output
+for the above python program:
+
+```
+begin to delete tensor
+deleter is called!
+you should see the deleter has been called
+```
+ *
+ */
 
 void DLManagedTensorDeleter(struct DLManagedTensor* dl_managed_tensor) {
   // data is shared, so do NOT free data
@@ -31,6 +65,7 @@ void DLManagedTensorDeleter(struct DLManagedTensor* dl_managed_tensor) {
 
   // now delete the DLManagedTensor which is created with `new`
   delete dl_managed_tensor;
+  std::cout << "deleter is called!" << std::endl;
 }
 
 }  // namespace kaldi

--- a/src/pybind/dlpack/dlpack_deleter.cc
+++ b/src/pybind/dlpack/dlpack_deleter.cc
@@ -1,0 +1,36 @@
+// pybind/dlpack/dlpack_deleter.cc
+
+// Copyright 2019   Mobvoi AI Lab, Beijing, China
+//                  (author: Fangjun Kuang, Yaguang Hu, Jian Wang)
+
+// See ../../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dlpack/dlpack_deleter.h"
+
+namespace kaldi {
+
+void DLManagedTensorDeleter(struct DLManagedTensor* dl_managed_tensor) {
+  // data is shared, so do NOT free data
+
+  // `shape` is created with `new[]`
+  delete[] dl_managed_tensor->dl_tensor.shape;
+
+  // `strides` is created with `new[]`
+  delete[] dl_managed_tensor->dl_tensor.strides;
+
+  // now delete the DLManagedTensor which is created with `new`
+  delete dl_managed_tensor;
+}
+
+}  // namespace kaldi

--- a/src/pybind/dlpack/dlpack_deleter.h
+++ b/src/pybind/dlpack/dlpack_deleter.h
@@ -1,0 +1,28 @@
+// pybind/dlpck/dlpack_deleter.h
+
+// Copyright 2019   Mobvoi AI Lab, Beijing, China
+//                  (author: Fangjun Kuang, Yaguang Hu, Jian Wang)
+
+// See ../../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KALDI_PYBIND_DLPACK_DLPACK_DELETER_H_
+#define KALDI_PYBIND_DLPACK_DLPACK_DELETER_H_
+
+#include "dlpack/dlpack.h"
+
+namespace kaldi {
+void DLManagedTensorDeleter(struct DLManagedTensor* dl_managed_tensor);
+}  // namespace kaldi
+
+#endif  // KALDI_PYBIND_DLPACK_DLPACK_DELETER_H_

--- a/src/pybind/dlpack/dlpack_pybind.cc
+++ b/src/pybind/dlpack/dlpack_pybind.cc
@@ -43,6 +43,9 @@ void pybind_dlpack(py::module& m) {
     KALDI_ASSERT(tensor->dtype.bits == 32);
     KALDI_ASSERT(tensor->dtype.lanes == 1);
 
+    auto* ctx = &tensor->ctx;
+    KALDI_ASSERT(ctx->device_type == kDLCPU);
+
     return SubVector<float>(reinterpret_cast<float*>(tensor->data),
                             tensor->shape[0]);
   });
@@ -59,6 +62,9 @@ void pybind_dlpack(py::module& m) {
     KALDI_ASSERT(tensor->dtype.code == kDLFloat);
     KALDI_ASSERT(tensor->dtype.bits == 32);
     KALDI_ASSERT(tensor->dtype.lanes == 1);
+
+    auto* ctx = &tensor->ctx;
+    KALDI_ASSERT(ctx->device_type == kDLCPU);
 
     // DLPack assumes row major, so we use strides[0]
     return SubMatrix<float>(reinterpret_cast<float*>(tensor->data),
@@ -80,6 +86,10 @@ void pybind_dlpack(py::module& m) {
     KALDI_ASSERT(tensor->dtype.bits == 32);
     KALDI_ASSERT(tensor->dtype.lanes == 1);
 
+    auto* ctx = &tensor->ctx;
+    KALDI_ASSERT(ctx->device_type == kDLGPU);
+    KALDI_ASSERT(ctx->device_id == CuDevice::GetCurrentDeviceId());
+
     return CuSubVector<float>(reinterpret_cast<float*>(tensor->data),
                               tensor->shape[0]);
 #else
@@ -100,6 +110,10 @@ void pybind_dlpack(py::module& m) {
     KALDI_ASSERT(tensor->dtype.code == kDLFloat);
     KALDI_ASSERT(tensor->dtype.bits == 32);
     KALDI_ASSERT(tensor->dtype.lanes == 1);
+
+    auto* ctx = &tensor->ctx;
+    KALDI_ASSERT(ctx->device_type == kDLGPU);
+    KALDI_ASSERT(ctx->device_id == CuDevice::GetCurrentDeviceId());
 
     // DLPack assumes row major, so we use strides[0]
     return CuSubMatrix<float>(reinterpret_cast<float*>(tensor->data),

--- a/src/pybind/dlpack/dlpack_pybind.cc
+++ b/src/pybind/dlpack/dlpack_pybind.cc
@@ -93,7 +93,8 @@ void pybind_dlpack(py::module& m) {
     return CuSubVector<float>(reinterpret_cast<float*>(tensor->data),
                               tensor->shape[0]);
 #else
-      KALDI_ERR << "Kaldi is not compiled with GPU!"
+    KALDI_ERR << "Kaldi is not compiled with GPU!";
+    return py::none();
 #endif
   });
 
@@ -120,7 +121,8 @@ void pybind_dlpack(py::module& m) {
                               tensor->shape[0], tensor->shape[1],
                               tensor->strides[0]);
 #else
-      KALDI_ERR << "Kaldi is not compiled with GPU!"
+    KALDI_ERR << "Kaldi is not compiled with GPU!";
+    return py::none();
 #endif
   });
 }

--- a/src/pybind/dlpack/dlpack_pybind.cc
+++ b/src/pybind/dlpack/dlpack_pybind.cc
@@ -18,111 +18,431 @@
 
 #include "dlpack/dlpack_pybind.h"
 
+#include <string.h>  // for strcmp
+
 #include "dlpack/dlpack.h"
+#include "dlpack/dlpack_deleter.h"
 
 #include "cudamatrix/cu-matrix.h"
 #include "cudamatrix/cu-vector.h"
 #include "matrix/kaldi-matrix.h"
 #include "matrix/kaldi-vector.h"
 
+namespace {
+
+using namespace kaldi;
+
+// refer to
+// https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L375
+// https://github.com/microsoft/onnxruntime-tvm/blob/master/python/tvm/_ffi/_ctypes/ndarray.py#L28
+// https://github.com/cupy/cupy/blob/master/cupy/core/dlpack.pyx#L66
+// PyTorch, TVM and CuPy name the created dltensor to be `dltensor`
+const char* kDLPackTensorName = "dltensor";
+
+// refer to
+// https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L402
+// https://github.com/apache/incubator-tvm/blob/master/python/tvm/_ffi/_ctypes/ndarray.py#L29
+// https://github.com/cupy/cupy/blob/master/cupy/core/dlpack.pyx#L62
+// PyTorch, TVM and CuPy name the used dltensor to be `used_dltensor`
+const char* kDLPackUsedTensorName = "used_dltensor";
+
+DLManagedTensor* CreateDLManagedtensor(DLDeviceType device_type, int device_id,
+                                       void* data) {
+  // As SubVector/SubMatrix/CuSubVector/CuSumMatrix
+  // all require a DLManagedTensor, we put the shared
+  // code here to avoid duplicates
+
+  // the created `managed_tensor` will be freed in
+  // `DLManagedTensorDeleter`, which does not free `data`,
+  // so no memory leak here
+  auto* managed_tensor = new DLManagedTensor();
+  managed_tensor->manager_ctx = nullptr;
+
+  // setup the deleter to free allocated memory.
+  // refer to
+  // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L361
+  // for how and when the deleter is invoked.
+  managed_tensor->deleter = &DLManagedTensorDeleter;
+
+  auto* tensor = &managed_tensor->dl_tensor;
+  tensor->data = data;
+  tensor->ctx.device_type = device_type;
+  tensor->ctx.device_id = device_id;
+
+  tensor->dtype.code = kDLFloat;
+  tensor->dtype.bits = 32;  // single precision float
+  tensor->dtype.lanes = 1;
+
+  tensor->byte_offset = 0;
+
+  // ndim, shape, strides are set outside
+  return managed_tensor;
+}
+
+DLManagedTensor* ConsumeDLManagedtensor(py::capsule* capsule,
+                                        DLDeviceType device_type, int device_id,
+                                        int ndim) {
+  // check the name of the capsule
+  if (strcmp(kDLPackTensorName, capsule->name()) != 0) {
+    // the following error message is modified from
+    // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L384
+    KALDI_ERR << "Expected capsule name: " << kDLPackTensorName << "\n"
+              << "But got: " << capsule->name() << "\n"
+              << "Note that DLTensor capsules can be consumed only once,\n"
+              << "so you might have already constructed a tensor from it once.";
+    return nullptr;
+  }
+
+  PyCapsule_SetName(capsule->ptr(), kDLPackUsedTensorName);
+
+  DLManagedTensor* managed_tensor = *capsule;
+  // (fangjun): the above assignment will either throw or succeed with a
+  // non-null ptr so no need to check for nullptr below
+
+  auto* tensor = &managed_tensor->dl_tensor;
+
+  KALDI_ASSERT(tensor->ndim == ndim);
+
+  // we support only float (single precision, 32-bit) tensor
+  KALDI_ASSERT(tensor->dtype.code == kDLFloat);
+  KALDI_ASSERT(tensor->dtype.bits == 32);
+  KALDI_ASSERT(tensor->dtype.lanes == 1);
+
+  auto* ctx = &tensor->ctx;
+  KALDI_ASSERT(ctx->device_type == device_type);
+  if (device_type == kDLGPU) {
+    KALDI_ASSERT(ctx->device_id == device_id);
+  }
+  return managed_tensor;
+}
+
+// this function is modified from
+// https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L355
+void DLPackCapsuleDestructor(PyObject* data) {
+  DLManagedTensor* managed_tensor = reinterpret_cast<DLManagedTensor*>(
+      PyCapsule_GetPointer(data, kDLPackTensorName));
+
+  // if managed_tensor is nullptr, then there is an error; we MUST
+  // clear the error flag manually by using PyErr_Clear().
+  // See https://docs.python.org/3/c-api/capsule.html#c.PyCapsule_GetPointer
+
+  if (managed_tensor && managed_tensor->deleter) {
+    // the managed_tensor has not been consumed, call deleter ourselves
+    managed_tensor->deleter(managed_tensor);
+  } else {
+    // the managed_tensor has been consumed
+    // PyCapsule_GetPointer has set an error indicator
+    PyErr_Clear();
+  }
+}
+
+}  // namespace
+
+namespace kaldi {
+
+/*
+To test the deleter function of `VectorToDLPack`, you can use the following
+methods (first print a log inside the deleter function)
+
+(1) When the capsule has not been consumed, call the deleter by ourselves
+
+```python
+import kaldi
+
+v = kaldi.FloatVector(2)
+
+dlpack = v.to_dlpack()
+print('del dlpack')
+del dlpack
+print('after del dlpack')
+```
+
+You should see
+
+```
+del dlpack
+<the log message you added in the deleter>
+after del dlpack
+```
+
+(2) When the capsule has been consumed, the deleter is also invoked.
+
+```python
+import torch
+from torch.utils.dlpack import from_dlpack
+
+import kaldi
+
+v = kaldi.FloatVector(2)
+
+dlpack = v.to_dlpack()
+tensor = from_dlpack(dlpack)
+print('del tensor')
+del tensor
+print('after del tensor')
+```
+
+You should see
+
+```
+del tensor
+<the log message you added in the deleter>
+after del tensor
+```
+*/
+
+py::capsule VectorToDLPack(VectorBase<float>* v) {
+  auto* managed_tensor = CreateDLManagedtensor(kDLCPU, 0, v->Data());
+  auto* tensor = &managed_tensor->dl_tensor;
+
+  tensor->ndim = 1;
+
+  // `shape` and `strides` are freed in `DLManagedTensorDeleter`, so
+  // no memory leak here .
+  tensor->shape = new int64_t[1];
+  tensor->shape[0] = v->Dim();
+
+  tensor->strides = new int64_t[1];
+  tensor->strides[0] = 1;
+
+  PyObject* capsule =
+      PyCapsule_New(managed_tensor, kDLPackTensorName, DLPackCapsuleDestructor);
+  bool is_borrowed = false;
+  return py::object(capsule, is_borrowed);
+  // `py::object` will free `capsule` created above in its destructor
+  // `py::object` is implicitly converted to `py::capsule`
+}
+
+py::capsule MatrixToDLPack(MatrixBase<float>* m) {
+  auto* managed_tensor = CreateDLManagedtensor(kDLCPU, 0, m->Data());
+  auto* tensor = &managed_tensor->dl_tensor;
+
+  tensor->ndim = 2;
+
+  // `shape` and `strides` are freed in `DLManagedTensorDeleter`, so
+  // no memory leak here
+  tensor->shape = new int64_t[2];
+  tensor->shape[0] = m->NumRows();
+  tensor->shape[1] = m->NumCols();
+
+  tensor->strides = new int64_t[2];
+  tensor->strides[0] = m->Stride();
+  tensor->strides[1] = 1;
+
+  PyObject* capsule =
+      PyCapsule_New(managed_tensor, kDLPackTensorName, DLPackCapsuleDestructor);
+  bool is_borrowed = false;
+  return py::object(capsule, is_borrowed);
+}
+
+py::capsule CuVectorToDLPack(CuVectorBase<float>* v) {
+#if HAVE_CUDA == 1
+  auto* managed_tensor =
+      CreateDLManagedtensor(kDLGPU, CuDevice::GetCurrentDeviceId(), v->Data());
+
+  auto* tensor = &managed_tensor->dl_tensor;
+
+  tensor->ndim = 1;
+
+  // `shape` and `strides` are freed in `DLManagedTensorDeleter`,
+  // so no memory leak here.
+  tensor->shape = new int64_t[1];
+  tensor->shape[0] = v->Dim();
+
+  tensor->strides = new int64_t[1];
+  tensor->strides[0] = 1;
+
+  PyObject* capsule =
+      PyCapsule_New(managed_tensor, kDLPackTensorName, DLPackCapsuleDestructor);
+  bool is_borrowed = false;
+  return py::object(capsule, is_borrowed);
+#else
+  KALDI_ERR << "Kaldi is not compiled with GPU!";
+  return py::none();
+#endif
+}
+
+py::capsule CuMatrixToDLPack(CuMatrixBase<float>* m) {
+#if HAVE_CUDA == 1
+  auto* managed_tensor =
+      CreateDLManagedtensor(kDLGPU, CuDevice::GetCurrentDeviceId(), m->Data());
+
+  auto* tensor = &managed_tensor->dl_tensor;
+
+  tensor->ndim = 2;
+
+  // `shape` and `strides` are freed in `DLManagedTensorDeleter`,
+  // so no memory leak here
+  tensor->shape = new int64_t[2];
+  tensor->shape[0] = m->NumRows();
+  tensor->shape[1] = m->NumCols();
+
+  tensor->strides = new int64_t[2];
+  tensor->strides[0] = m->Stride();
+  tensor->strides[1] = 1;
+
+  PyObject* capsule =
+      PyCapsule_New(managed_tensor, kDLPackTensorName, DLPackCapsuleDestructor);
+  bool is_borrowed = false;
+  return py::object(capsule, is_borrowed);
+#else
+  KALDI_ERR << "Kaldi is not compiled with GPU!";
+  return py::none();
+#endif
+}
+
+// As the destructor of `VectorBase<float>` is not `virtual`
+// we cannot return a `VectorBase<float>*` or `SubVector<float>*`.
+DLPackSubVector<float>* SubVectorFromDLPack(py::capsule* capsule) {
+  auto* managed_tensor = ConsumeDLManagedtensor(capsule, kDLCPU, 0, 1);
+  auto* tensor = &managed_tensor->dl_tensor;
+
+  // we use `py::return_value_policy::take_ownership`
+  // and rely on Python to delete the allocated memory.
+  //
+  // https://pybind11.readthedocs.io/en/stable/advanced/functions.html
+  // says: "When Python’s garbage collector eventually deletes the Python
+  // wrapper, pybind11 will also attempt to delete the C++ instance (via
+  // operator delete()) due to the implied ownership."
+  //
+  // Therefore, we use `new` instead of `malloc` with `placement new` here.
+  return new DLPackSubVector<float>(reinterpret_cast<float*>(tensor->data),
+                                    tensor->shape[0], managed_tensor);
+  // clang-format off
+/*
+You can use the following method to check that the above allocated
+memory is indeed freed.
+
+1. Put a `std::cout` statement or use `KALDI_LOG` inside
+the destructor of `DLPackSubVector`
+
+2. Run the following Python test code
+
+```python
+import torch
+from torch.utils.dlpack import to_dlpack
+import kaldi
+
+tensor = torch.tensor([1, 2]).float()
+
+dlpack = to_dlpack(tensor)
+v = kaldi.SubVectorFromDLPack(dlpack)
+print('del v')
+del v
+print('after del v')
+```
+You should see
+
+```
+del v
+<the log message you added inside the destructor of DLPackSubVector>
+after del v
+```
+
+Since the destructor is called, we can trust Pybind11 that it
+invokes the `delete` operator to free the memory allocated by `new`.
+*/
+  // clang-format on
+}
+
+DLPackSubMatrix<float>* SubMatrixFromDLPack(py::capsule* capsule) {
+  auto* managed_tensor = ConsumeDLManagedtensor(capsule, kDLCPU, 0, 2);
+  auto* tensor = &managed_tensor->dl_tensor;
+
+  // DLPack assumes row major, so we use strides[0]
+  return new DLPackSubMatrix<float>(reinterpret_cast<float*>(tensor->data),
+                                    tensor->shape[0], tensor->shape[1],
+                                    tensor->strides[0], managed_tensor);
+}
+
+DLPackCuSubVector<float>* CuSubVectorFromDLPack(py::capsule* capsule) {
+#if HAVE_CUDA == 1
+  auto* managed_tensor = ConsumeDLManagedtensor(
+      capsule, kDLGPU, CuDevice::GetCurrentDeviceId(), 1);
+  auto* tensor = &managed_tensor->dl_tensor;
+
+  return new DLPackCuSubVector<float>(reinterpret_cast<float*>(tensor->data),
+                                      tensor->shape[0], managed_tensor);
+#else
+  KALDI_ERR << "Kaldi is not compiled with GPU!";
+  return py::none();
+#endif
+  // clang-format off
+/*
+You can use the following methods to check that the
+desturctor of `DLPackCuSubVector` is invoked from Python
+and thus there is no memory leak in the above `new statement`.
+
+1. print some log in the destructor of DLPackCuSubVector
+
+2. try the following code
+
+```python
+import torch
+from torch.utils.dlpack import to_dlpack
+import kaldi
+
+device_id = 0
+device = torch.device('cuda', device_id)
+
+tensor = torch.tensor([1, 2]).float()
+tensor = tensor.to(device)
+dlpack = to_dlpack(tensor)
+
+kaldi.SelectGpuDevice(device_id=device_id)
+v = kaldi.CuSubVectorFromDLPack(dlpack)
+print('del v')
+del v
+print('after del v')
+```
+
+You shoulde see something like this:
+
+```
+del v
+<the log message you added inside the destructor>
+after del v
+```
+ */
+  // clang-format on
+}
+
+DLPackCuSubMatrix<float>* CuSubMatrixFromDLPack(py::capsule* capsule) {
+#if HAVE_CUDA == 1
+  auto* managed_tensor = ConsumeDLManagedtensor(
+      capsule, kDLGPU, CuDevice::GetCurrentDeviceId(), 2);
+  auto* tensor = &managed_tensor->dl_tensor;
+
+  // DLPack assumes row major, so we use strides[0]
+  return new DLPackCuSubMatrix<float>(reinterpret_cast<float*>(tensor->data),
+                                      tensor->shape[0], tensor->shape[1],
+                                      tensor->strides[0], managed_tensor);
+#else
+  KALDI_ERR << "Kaldi is not compiled with GPU!";
+  return py::none();
+#endif
+}
+
+}  // namespace kaldi
+
 using namespace kaldi;
 
 void pybind_dlpack(py::module& m) {
-  m.def("ToSubVector", [](py::capsule* capsule) {
-    DLManagedTensor* managed_tensor = *capsule;
-    // (fangjun): the above assignment will either throw or succeed with a
-    // non-null ptr so no need to check for nullptr below
+  m.def("SubVectorFromDLPack",
+        [](py::capsule* capsule) { return SubVectorFromDLPack(capsule); },
+        py::return_value_policy::take_ownership);
+  // we use `take_ownership` because it returns a pointer created with `new`
+  // and we want to transfer the ownership of the pointer to Python.
 
-    auto* tensor = &managed_tensor->dl_tensor;
+  m.def("SubMatrixFromDLPack",
+        [](py::capsule* capsule) { return SubMatrixFromDLPack(capsule); },
+        py::return_value_policy::take_ownership);
 
-    // we support only 1-D tensor
-    KALDI_ASSERT(tensor->ndim == 1);
+  m.def("CuSubVectorFromDLPack",
+        [](py::capsule* capsule) { return CuSubVectorFromDLPack(capsule); },
+        py::return_value_policy::take_ownership);
 
-    // we support only float (single precision, 32-bit) tensor
-    KALDI_ASSERT(tensor->dtype.code == kDLFloat);
-    KALDI_ASSERT(tensor->dtype.bits == 32);
-    KALDI_ASSERT(tensor->dtype.lanes == 1);
-
-    auto* ctx = &tensor->ctx;
-    KALDI_ASSERT(ctx->device_type == kDLCPU);
-
-    return SubVector<float>(reinterpret_cast<float*>(tensor->data),
-                            tensor->shape[0]);
-  });
-
-  m.def("ToSubMatrix", [](py::capsule* capsule) {
-    DLManagedTensor* managed_tensor = *capsule;
-
-    auto* tensor = &managed_tensor->dl_tensor;
-
-    // we support only 2-D tensor
-    KALDI_ASSERT(tensor->ndim == 2);
-
-    // we support only float (single precision, 32-bit) tensor
-    KALDI_ASSERT(tensor->dtype.code == kDLFloat);
-    KALDI_ASSERT(tensor->dtype.bits == 32);
-    KALDI_ASSERT(tensor->dtype.lanes == 1);
-
-    auto* ctx = &tensor->ctx;
-    KALDI_ASSERT(ctx->device_type == kDLCPU);
-
-    // DLPack assumes row major, so we use strides[0]
-    return SubMatrix<float>(reinterpret_cast<float*>(tensor->data),
-                            tensor->shape[0], tensor->shape[1],
-                            tensor->strides[0]);
-  });
-
-  m.def("ToCuSubVector", [](py::capsule* capsule) {
-#if HAVE_CUDA == 1
-    DLManagedTensor* managed_tensor = *capsule;
-
-    auto* tensor = &managed_tensor->dl_tensor;
-
-    // we support only 1-D tensor
-    KALDI_ASSERT(tensor->ndim == 1);
-
-    // we support only float (single precision, 32-bit) tensor
-    KALDI_ASSERT(tensor->dtype.code == kDLFloat);
-    KALDI_ASSERT(tensor->dtype.bits == 32);
-    KALDI_ASSERT(tensor->dtype.lanes == 1);
-
-    auto* ctx = &tensor->ctx;
-    KALDI_ASSERT(ctx->device_type == kDLGPU);
-    KALDI_ASSERT(ctx->device_id == CuDevice::GetCurrentDeviceId());
-
-    return CuSubVector<float>(reinterpret_cast<float*>(tensor->data),
-                              tensor->shape[0]);
-#else
-    KALDI_ERR << "Kaldi is not compiled with GPU!";
-    return py::none();
-#endif
-  });
-
-  m.def("ToCuSubMatrix", [](py::capsule* capsule) {
-#if HAVE_CUDA == 1
-    DLManagedTensor* managed_tensor = *capsule;
-
-    auto* tensor = &managed_tensor->dl_tensor;
-
-    // we support only 2-D tensor
-    KALDI_ASSERT(tensor->ndim == 2);
-
-    // we support only float (single precision, 32-bit) tensor
-    KALDI_ASSERT(tensor->dtype.code == kDLFloat);
-    KALDI_ASSERT(tensor->dtype.bits == 32);
-    KALDI_ASSERT(tensor->dtype.lanes == 1);
-
-    auto* ctx = &tensor->ctx;
-    KALDI_ASSERT(ctx->device_type == kDLGPU);
-    KALDI_ASSERT(ctx->device_id == CuDevice::GetCurrentDeviceId());
-
-    // DLPack assumes row major, so we use strides[0]
-    return CuSubMatrix<float>(reinterpret_cast<float*>(tensor->data),
-                              tensor->shape[0], tensor->shape[1],
-                              tensor->strides[0]);
-#else
-    KALDI_ERR << "Kaldi is not compiled with GPU!";
-    return py::none();
-#endif
-  });
+  m.def("CuSubMatrixFromDLPack",
+        [](py::capsule* capsule) { return CuSubMatrixFromDLPack(capsule); },
+        py::return_value_policy::take_ownership);
 }

--- a/src/pybind/dlpack/dlpack_pybind.cc
+++ b/src/pybind/dlpack/dlpack_pybind.cc
@@ -191,7 +191,7 @@ after del tensor
 ```
 */
 
-py::capsule VectorToDLPack(VectorBase<float>* v) {
+py::capsule VectorToDLPack(Vector<float>* v) {
   auto* managed_tensor = CreateDLManagedtensor(kDLCPU, 0, v->Data());
   auto* tensor = &managed_tensor->dl_tensor;
 
@@ -213,7 +213,7 @@ py::capsule VectorToDLPack(VectorBase<float>* v) {
   // `py::object` is implicitly converted to `py::capsule`
 }
 
-py::capsule MatrixToDLPack(MatrixBase<float>* m) {
+py::capsule MatrixToDLPack(Matrix<float>* m) {
   auto* managed_tensor = CreateDLManagedtensor(kDLCPU, 0, m->Data());
   auto* tensor = &managed_tensor->dl_tensor;
 
@@ -235,7 +235,7 @@ py::capsule MatrixToDLPack(MatrixBase<float>* m) {
   return py::object(capsule, is_borrowed);
 }
 
-py::capsule CuVectorToDLPack(CuVectorBase<float>* v) {
+py::capsule CuVectorToDLPack(CuVector<float>* v) {
 #if HAVE_CUDA == 1
   auto* managed_tensor =
       CreateDLManagedtensor(kDLGPU, CuDevice::GetCurrentDeviceId(), v->Data());
@@ -262,7 +262,7 @@ py::capsule CuVectorToDLPack(CuVectorBase<float>* v) {
 #endif
 }
 
-py::capsule CuMatrixToDLPack(CuMatrixBase<float>* m) {
+py::capsule CuMatrixToDLPack(CuMatrix<float>* m) {
 #if HAVE_CUDA == 1
   auto* managed_tensor =
       CreateDLManagedtensor(kDLGPU, CuDevice::GetCurrentDeviceId(), m->Data());

--- a/src/pybind/dlpack/dlpack_pybind.h
+++ b/src/pybind/dlpack/dlpack_pybind.h
@@ -28,10 +28,10 @@ void pybind_dlpack(py::module& m);
 
 namespace kaldi {
 
-py::capsule VectorToDLPack(VectorBase<float>* v);
-py::capsule MatrixToDLPack(MatrixBase<float>* m);
-py::capsule CuVectorToDLPack(CuVectorBase<float>* v);
-py::capsule CuMatrixToDLPack(CuMatrixBase<float>* m);
+py::capsule VectorToDLPack(Vector<float>* v);
+py::capsule MatrixToDLPack(Matrix<float>* m);
+py::capsule CuVectorToDLPack(CuVector<float>* v);
+py::capsule CuMatrixToDLPack(CuMatrix<float>* m);
 
 DLPackSubVector<float>* SubVectorFromDLPack(py::capsule* capsule);
 DLPackSubMatrix<float>* SubMatrixFromDLPack(py::capsule* capsule);

--- a/src/pybind/dlpack/dlpack_submatrix.cc
+++ b/src/pybind/dlpack/dlpack_submatrix.cc
@@ -1,4 +1,4 @@
-// pybind/dlpck/dlpack_pybind.h
+// pybind/dlpack/dlpack_submatrix.cc
 
 // Copyright 2019   Mobvoi AI Lab, Beijing, China
 //                  (author: Fangjun Kuang, Yaguang Hu, Jian Wang)
@@ -16,28 +16,11 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef KALDI_PYBIND_DLPACK_DLPACK_PYBIND_H_
-#define KALDI_PYBIND_DLPACK_DLPACK_PYBIND_H_
-
-#include "pybind/kaldi_pybind.h"
-
 #include "dlpack/dlpack_submatrix.h"
-#include "dlpack/dlpack_subvector.h"
-
-void pybind_dlpack(py::module& m);
 
 namespace kaldi {
 
-py::capsule VectorToDLPack(VectorBase<float>* v);
-py::capsule MatrixToDLPack(MatrixBase<float>* m);
-py::capsule CuVectorToDLPack(CuVectorBase<float>* v);
-py::capsule CuMatrixToDLPack(CuMatrixBase<float>* m);
-
-DLPackSubVector<float>* SubVectorFromDLPack(py::capsule* capsule);
-DLPackSubMatrix<float>* SubMatrixFromDLPack(py::capsule* capsule);
-DLPackCuSubVector<float>* CuSubVectorFromDLPack(py::capsule* capsule);
-DLPackCuSubMatrix<float>* CuSubMatrixFromDLPack(py::capsule* capsule);
+template class DLPackSubMatrix<float>;
+template class DLPackCuSubMatrix<float>;
 
 }  // namespace kaldi
-
-#endif  // KALDI_PYBIND_DLPACK_DLPACK_PYBIND_H_

--- a/src/pybind/dlpack/dlpack_submatrix.h
+++ b/src/pybind/dlpack/dlpack_submatrix.h
@@ -1,0 +1,103 @@
+// pybind/dlpck/dlpack_submatrix.h
+
+// Copyright 2019   Mobvoi AI Lab, Beijing, China
+//                  (author: Fangjun Kuang, Yaguang Hu, Jian Wang)
+
+// See ../../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KALDI_PYBIND_DLPACK_DLPACK_SUBMATRIX_H_
+#define KALDI_PYBIND_DLPACK_DLPACK_SUBMATRIX_H_
+
+#include "dlpack/dlpack.h"
+
+#include "cudamatrix/cu-matrix.h"
+#include "matrix/kaldi-matrix.h"
+
+namespace kaldi {
+
+/*
+The following comment is copied from
+https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L387
+
+```
+DLManagedTensor * dlMTensor = (DLManagedTensor *)PyCapsule_GetPointer(data,
+"dltensor");
+// atensor steals the ownership of the underlying storage. It also passes a
+// destructor function that will be called when the underlying storage goes
+// out of scope. When the destructor is called, the dlMTensor is destructed too.
+auto atensor = at::fromDLPack(dlMTensor);
+```
+
+We cannot construct a `SuMatrix` from dlpack since `SubMatrix`
+cannot invoke the `deleter` of `DLManagedTensor` in the destructor.
+
+Therefore, we create `DLPackSubMatrix` to free the `DLManagedTensor` passed
+from Python by `PyCapsule`.
+
+`DLPackSubMatrix` is a subclass of `SubMatrix` and we can pass a pointer
+of `DLPackSubMatrix` to any function that accepts `SubMatrix<float>*`
+or `MatrixBase<float>*`.
+*/
+
+template <typename Real>
+class DLPackSubMatrix : public SubMatrix<Real> {
+ public:
+  // note that unlike with `DLPackSubVector`, it requires
+  // `Real* data` instead of `const Real* data`.
+  DLPackSubMatrix(Real* data, MatrixIndexT num_rows, MatrixIndexT num_cols,
+                  MatrixIndexT stride, DLManagedTensor* ptr)
+      : SubMatrix<Real>(data, num_rows, num_cols, stride),
+        dl_managed_tensor_(ptr) {}
+
+  DLPackSubMatrix(const DLPackSubMatrix&) = delete;
+  DLPackSubMatrix& operator=(const DLPackSubMatrix&) = delete;
+
+  ~DLPackSubMatrix() {
+    if (dl_managed_tensor_ && dl_managed_tensor_->deleter) {
+      dl_managed_tensor_->deleter(dl_managed_tensor_);
+    }
+    // TODO(fangjun): remove this log
+    std::cout << "dlpack SubMatrix is called" << std::endl;
+  }
+
+ private:
+  DLManagedTensor* dl_managed_tensor_ = nullptr;
+};
+
+template <typename Real>
+class DLPackCuSubMatrix : public CuSubMatrix<Real> {
+ public:
+  DLPackCuSubMatrix(const Real* data, const MatrixIndexT num_rows,
+                    const MatrixIndexT num_cols, const MatrixIndexT stride,
+                    DLManagedTensor* ptr)
+      : CuSubMatrix<Real>(data, num_rows, num_cols, stride),
+        dl_managed_tensor_(ptr) {}
+
+  DLPackCuSubMatrix(const DLPackCuSubMatrix&) = delete;
+  DLPackCuSubMatrix& operator=(const DLPackCuSubMatrix&) = delete;
+
+  ~DLPackCuSubMatrix() {
+    if (dl_managed_tensor_ && dl_managed_tensor_->deleter) {
+      dl_managed_tensor_->deleter(dl_managed_tensor_);
+    }
+    std::cout << "dlpack CuSubMatrix is called" << std::endl;
+  }
+
+ private:
+  DLManagedTensor* dl_managed_tensor_ = nullptr;
+};
+
+}  // namespace kaldi
+
+#endif  // KALDI_PYBIND_DLPACK_DLPACK_SUBMATRIX_H_

--- a/src/pybind/dlpack/dlpack_subvector.cc
+++ b/src/pybind/dlpack/dlpack_subvector.cc
@@ -1,4 +1,4 @@
-// pybind/dlpck/dlpack_pybind.h
+// pybind/dlpack/dlpack_subvector.cc
 
 // Copyright 2019   Mobvoi AI Lab, Beijing, China
 //                  (author: Fangjun Kuang, Yaguang Hu, Jian Wang)
@@ -16,28 +16,11 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef KALDI_PYBIND_DLPACK_DLPACK_PYBIND_H_
-#define KALDI_PYBIND_DLPACK_DLPACK_PYBIND_H_
-
-#include "pybind/kaldi_pybind.h"
-
-#include "dlpack/dlpack_submatrix.h"
 #include "dlpack/dlpack_subvector.h"
-
-void pybind_dlpack(py::module& m);
 
 namespace kaldi {
 
-py::capsule VectorToDLPack(VectorBase<float>* v);
-py::capsule MatrixToDLPack(MatrixBase<float>* m);
-py::capsule CuVectorToDLPack(CuVectorBase<float>* v);
-py::capsule CuMatrixToDLPack(CuMatrixBase<float>* m);
-
-DLPackSubVector<float>* SubVectorFromDLPack(py::capsule* capsule);
-DLPackSubMatrix<float>* SubMatrixFromDLPack(py::capsule* capsule);
-DLPackCuSubVector<float>* CuSubVectorFromDLPack(py::capsule* capsule);
-DLPackCuSubMatrix<float>* CuSubMatrixFromDLPack(py::capsule* capsule);
+template class DLPackSubVector<float>;
+template class DLPackCuSubVector<float>;
 
 }  // namespace kaldi
-
-#endif  // KALDI_PYBIND_DLPACK_DLPACK_PYBIND_H_

--- a/src/pybind/dlpack/dlpack_subvector.h
+++ b/src/pybind/dlpack/dlpack_subvector.h
@@ -1,0 +1,90 @@
+// pybind/dlpck/dlpack_subvector.h
+
+// Copyright 2019   Mobvoi AI Lab, Beijing, China
+//                  (author: Fangjun Kuang, Yaguang Hu, Jian Wang)
+
+// See ../../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KALDI_PYBIND_DLPACK_DLPACK_SUBVECTOR_H_
+#define KALDI_PYBIND_DLPACK_DLPACK_SUBVECTOR_H_
+
+#include "dlpack/dlpack.h"
+
+#include "cudamatrix/cu-vector.h"
+#include "matrix/kaldi-vector.h"
+
+namespace kaldi {
+
+/*
+The following comment is copied from
+https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L387
+
+```
+DLManagedTensor * dlMTensor = (DLManagedTensor *)PyCapsule_GetPointer(data,
+"dltensor");
+// atensor steals the ownership of the underlying storage. It also passes a
+// destructor function that will be called when the underlying storage goes
+// out of scope. When the destructor is called, the dlMTensor is destructed too.
+auto atensor = at::fromDLPack(dlMTensor);
+```
+
+We create `DLPackSubVector` to free `DLManagedTensor` passed
+from Python by `PyCapsule`.
+*/
+
+template <typename Real>
+class DLPackSubVector : public SubVector<Real> {
+ public:
+  // Note that `const Real* data` will be `const_cast`
+  // to `Real *`
+  DLPackSubVector(const Real* data, MatrixIndexT length, DLManagedTensor* ptr)
+      : SubVector<Real>(data, length), dl_managed_tensor_(ptr) {}
+
+  DLPackSubVector(const DLPackSubVector&) = delete;
+  DLPackSubVector& operator=(const DLPackSubVector&) = delete;
+
+  ~DLPackSubVector() {
+    if (dl_managed_tensor_ && dl_managed_tensor_->deleter) {
+      dl_managed_tensor_->deleter(dl_managed_tensor_);
+    }
+    std::cout << "dlpack subvector is called" << std::endl;
+  }
+
+ private:
+  DLManagedTensor* dl_managed_tensor_ = nullptr;
+};
+
+template <typename Real>
+class DLPackCuSubVector : public CuSubVector<Real> {
+ public:
+  DLPackCuSubVector(const Real* data, MatrixIndexT length, DLManagedTensor* ptr)
+      : CuSubVector<Real>(data, length), dl_managed_tensor_(ptr) {}
+
+  DLPackCuSubVector(const DLPackCuSubVector&) = delete;
+  DLPackCuSubVector& operator=(const DLPackCuSubVector&) = delete;
+
+  ~DLPackCuSubVector() {
+    if (dl_managed_tensor_ && dl_managed_tensor_->deleter) {
+      dl_managed_tensor_->deleter(dl_managed_tensor_);
+    }
+    std::cout << "dlpack CuSubVector is called" << std::endl;
+  }
+
+ private:
+  DLManagedTensor* dl_managed_tensor_ = nullptr;
+};
+
+}  // namespace kaldi
+
+#endif  // KALDI_PYBIND_DLPACK_DLPACK_SUBVECTOR_H_

--- a/src/pybind/feat/online_feature_pybind.cc
+++ b/src/pybind/feat/online_feature_pybind.cc
@@ -1,0 +1,108 @@
+// pybind/feat/online_feature_pybind.cc
+
+// Copyright 2019   Microsoft Corporation (author: Xingyu Na)
+
+// See ../../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "feat/online_feature_pybind.h"
+
+#include "feat/feature-mfcc.h"
+#include "feat/feature-fbank.h"
+#include "feat/online-feature.h"
+
+using namespace kaldi;
+  
+template <class Feature>
+void online_base_feature(py::module& m, const std::string& feat_type) {
+  py::class_<OnlineGenericBaseFeature<Feature>, OnlineBaseFeature>(m, feat_type.c_str())
+      .def(py::init<const typename Feature::Options&>(), py::arg("opts"));
+}
+
+void pybind_online_feature(py::module& m) {
+  py::class_<OnlineFeatureInterface>(m, "OnlineFeatureInterface",
+      "OnlineFeatureInterface is an interface for online feature processing."
+      "This interface only specifies how the object *outputs* the features."
+      "How it obtains the features, e.g. from a previous object or objects of type"
+      "OnlineFeatureInterface, is not specified in the interface and you will"
+      "likely define new constructors or methods in the derived type to do that.")
+      .def("Dim", &OnlineFeatureInterface::Dim)
+      .def("NumFramesReady", &OnlineFeatureInterface::NumFramesReady)
+      .def("IsLastFrame", &OnlineFeatureInterface::IsLastFrame)
+      .def("GetFrame", &OnlineFeatureInterface::GetFrame)
+      .def("GetFrames", &OnlineFeatureInterface::GetFrames)
+      .def("FrameShiftInSeconds", &OnlineFeatureInterface::FrameShiftInSeconds);
+
+  py::class_<OnlineBaseFeature, OnlineFeatureInterface>(m, "OnlineBaseFeature")
+      .def("AcceptWaveform", &OnlineBaseFeature::AcceptWaveform,
+           "This would be called from the application, when you get more wave data."
+           "Note: the sampling_rate is typically only provided so the code can assert"
+           "that it matches the sampling rate expected in the options.")
+      .def("InputFinished", &OnlineBaseFeature::InputFinished,
+           "InputFinished() tells the class you won't be providing any"
+           "more waveform.  This will help flush out the last few frames"
+           "of delta or LDA features (it will typically affect the return value"
+           "of IsLastFrame.");
+
+  online_base_feature<MfccComputer>(m, "OnlineMfcc");
+  online_base_feature<FbankComputer>(m, "OnlineFbank");
+
+  py::class_<OnlineCmvnOptions>(m, "OnlineCmvnOptions")
+      .def(py::init<>())
+      .def_readwrite("cmn_window", &OnlineCmvnOptions::cmn_window)
+      .def_readwrite("speaker_frames", &OnlineCmvnOptions::speaker_frames)
+      .def_readwrite("global_frames", &OnlineCmvnOptions::global_frames)
+      .def_readwrite("normalize_mean", &OnlineCmvnOptions::normalize_mean)
+      .def_readwrite("normalize_variance", &OnlineCmvnOptions::normalize_variance)
+      .def_readwrite("modulus", &OnlineCmvnOptions::modulus)
+      .def_readwrite("ring_buffer_size", &OnlineCmvnOptions::ring_buffer_size)
+      .def_readwrite("skip_dims", &OnlineCmvnOptions::skip_dims)
+      .def("Check", &OnlineCmvnOptions::Check);
+
+  py::class_<OnlineCmvnState>(m, "OnlineCmvnState",
+      "This bind is only used internally, so members are not exposed.")
+      .def(py::init<>())
+      .def(py::init<const Matrix<double>&>())
+      .def(py::init<const OnlineCmvnState&>());
+
+  py::class_<OnlineCmvn, OnlineFeatureInterface>(m, "OnlineCmvn")
+      .def(py::init<const OnlineCmvnOptions&, OnlineFeatureInterface*>(),
+           py::arg("opts"), py::arg("src"))
+      .def(py::init<const OnlineCmvnOptions&, const OnlineCmvnState&,
+           OnlineFeatureInterface*>(),
+           py::arg("opts"), py::arg("stat"), py::arg("src"))
+      .def("GetState", &OnlineCmvn::GetState)
+      .def("SetState", &OnlineCmvn::SetState)
+      .def("Freeze", &OnlineCmvn::Freeze);
+
+  py::class_<OnlineSpliceOptions>(m, "OnlineSpliceOptions")
+      .def(py::init<>())
+      .def_readwrite("left_context", &OnlineSpliceOptions::left_context)
+      .def_readwrite("right_context", &OnlineSpliceOptions::right_context);
+
+  py::class_<OnlineSpliceFrames, OnlineFeatureInterface>(m, "OnlineSpliceFrames")
+      .def(py::init<const OnlineSpliceOptions&, OnlineFeatureInterface*>(),
+           py::arg("opts"), py::arg("src"));
+
+  py::class_<OnlineTransform, OnlineFeatureInterface>(m, "OnlineTransform")
+      .def(py::init<const Matrix<float>&, OnlineFeatureInterface*>());
+
+  py::class_<OnlineCacheFeature, OnlineFeatureInterface>(m, "OnlineCacheFeature")
+      .def(py::init<OnlineFeatureInterface*>(), py::arg("src"))
+      .def("ClearCache", &OnlineCacheFeature::ClearCache);
+
+  py::class_<OnlineAppendFeature, OnlineFeatureInterface>(m, "OnlineAppendFeature")
+      .def(py::init<OnlineFeatureInterface*, OnlineFeatureInterface*>(),
+           py::arg("src1"), py::arg("src2"));
+
+}

--- a/src/pybind/feat/online_feature_pybind.h
+++ b/src/pybind/feat/online_feature_pybind.h
@@ -1,4 +1,4 @@
-// pybind/feat/feat_pybind.cc
+// pybind/feat/online_feature_pybind.h
 
 // Copyright 2019   Microsoft Corporation (author: Xingyu Na)
 
@@ -15,16 +15,11 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
-#include "feat/feat_pybind.h"
+#ifndef KALDI_PYBIND_FEAT_ONLINE_FEATURE_PYBIND_H_
+#define KALDI_PYBIND_FEAT_ONLINE_FEATURE_PYBIND_H_
 
-#include "feat/feature_pybind.h"
-#include "feat/online_feature_pybind.h"
-#include "feat/wave_reader_pybind.h"
+#include "pybind/kaldi_pybind.h"
 
-void pybind_feat(py::module& _m) {
-  py::module m = _m.def_submodule("feat", "feat pybind for Kaldi");
+void pybind_online_feature(py::module& m);
 
-  pybind_feature(m);
-  pybind_online_feature(m);
-  pybind_wave_reader(m);
-}
+#endif  // KALDI_PYBIND_FEAT_ONLINE_FEATURE_PYBIND_H_

--- a/src/pybind/fst/arc_pybind_test.py
+++ b/src/pybind/fst/arc_pybind_test.py
@@ -10,8 +10,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
 
 import unittest
 
-import numpy as np
-
 import kaldi_pybind.fst as fst
 
 

--- a/src/pybind/fst/fst_pybind_test.py
+++ b/src/pybind/fst/fst_pybind_test.py
@@ -9,8 +9,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
 
 import unittest
 
-import numpy as np
-
 import kaldi_pybind.fst as fst
 
 

--- a/src/pybind/fst/symbol_table_pybind_test.py
+++ b/src/pybind/fst/symbol_table_pybind_test.py
@@ -9,8 +9,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
 
 import unittest
 
-import numpy as np
-
 import kaldi_pybind.fst as fst
 import kaldi
 

--- a/src/pybind/fst/vector_fst_pybind_test.py
+++ b/src/pybind/fst/vector_fst_pybind_test.py
@@ -9,8 +9,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
 
 import unittest
 
-import numpy as np
-
 import kaldi_pybind.fst as fst
 import kaldi
 

--- a/src/pybind/fst/weight_pybind_test.py
+++ b/src/pybind/fst/weight_pybind_test.py
@@ -10,8 +10,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
 
 import unittest
 
-import numpy as np
-
 import kaldi_pybind.fst as fst
 
 

--- a/src/pybind/kaldi_pybind.cc
+++ b/src/pybind/kaldi_pybind.cc
@@ -55,4 +55,7 @@ PYBIND11_MODULE(kaldi_pybind, m) {
   pybind_dlpack(m);
 
   pybind_cudamatrix(m);
+
+  void test_dlpack(py::module & m);  // forward declaration
+  test_dlpack(m);
 }

--- a/src/pybind/matrix/matrix_common_pybind.cc
+++ b/src/pybind/matrix/matrix_common_pybind.cc
@@ -40,4 +40,14 @@ void pybind_matrix_common(py::module& m) {
       .value("kStrideEqualNumCols", kStrideEqualNumCols,
              "Set to the number of columns")
       .export_values();
+
+  py::enum_<MatrixTransposeType>(
+      m, "MatrixTransposeType", py::arithmetic(),
+      "this enums equal to CblasTrans and CblasNoTrans constants from CBLAS "
+      "library we are writing them as literals because we don't want to "
+      "include here matrix/kaldi-blas.h, which puts many symbols into global "
+      "scope (like 'real') via the header f2c.h")
+      .value("kTrans", kTrans, "CblasTrans == 112")
+      .value("kNoTrans", kNoTrans, "CblasNoTrans == 111")
+      .export_values();
 }

--- a/src/pybind/matrix/matrix_pybind.cc
+++ b/src/pybind/matrix/matrix_pybind.cc
@@ -92,4 +92,11 @@ void pybind_matrix(py::module& m) {
                                     info.shape[0], info.shape[1],
                                     info.strides[0] / sizeof(float));
       }));
+
+  py::class_<Matrix<double>,
+             std::unique_ptr<Matrix<double>, py::nodelete>>(
+      m, "DoubleMatrix",
+      "This bind is only for internal use, e.g. by OnlineCmvnState.")
+      .def(py::init<const Matrix<float>&>(), py::arg("src"));
+
 }

--- a/src/pybind/matrix/vector_pybind.cc
+++ b/src/pybind/matrix/vector_pybind.cc
@@ -45,25 +45,20 @@ void pybind_vector(py::module& m) {
            [](const VectorBase<float>& v, int i) { return v(i); })
       .def("__setitem__",
            [](VectorBase<float>& v, int i, float val) { v(i) = val; })
-      .def("numpy",
-           [](VectorBase<float>* v) {
-             return py::array_t<float>(
-                 {v->Dim()},       // shape
-                 {sizeof(float)},  // stride in bytes
-                 v->Data(),        // ptr
-                 py::none());      // pass a base object to avoid copy!
-             // (fangjun): the base object can be anything containing a non-null
-             // ptr. I cannot think of a better way than to pass a `None`
-             // object.
-             //
-             // `numpy` instead of `Numpy`, `ToNumpy` or `SomeOtherName` is used
-             // here because we want to follow the style in PyKaldi and PyTorch
-             // using  the  method `numpy()` to convert a matrix/tensor to a
-             // numpy array.
-           })
-      .def("to_dlpack", [](VectorBase<float>* v) {
-        // we use the name `to_dlpack` because PyTorch uses the same name
-        return VectorToDLPack(v);
+      .def("numpy", [](VectorBase<float>* v) {
+        return py::array_t<float>(
+            {v->Dim()},       // shape
+            {sizeof(float)},  // stride in bytes
+            v->Data(),        // ptr
+            py::none());      // pass a base object to avoid copy!
+        // (fangjun): the base object can be anything containing a non-null
+        // ptr. I cannot think of a better way than to pass a `None`
+        // object.
+        //
+        // `numpy` instead of `Numpy`, `ToNumpy` or `SomeOtherName` is used
+        // here because we want to follow the style in PyKaldi and PyTorch
+        // using  the  method `numpy()` to convert a matrix/tensor to a
+        // numpy array.
       });
 
   py::class_<Vector<float>, VectorBase<float>>(m, "FloatVector",
@@ -76,7 +71,11 @@ void pybind_vector(py::module& m) {
                                {sizeof(float)});  // strides (in chars)
       })
       .def(py::init<const MatrixIndexT, MatrixResizeType>(), py::arg("size"),
-           py::arg("resize_type") = kSetZero);
+           py::arg("resize_type") = kSetZero)
+      .def("to_dlpack", [](Vector<float>* v) {
+        // we use the name `to_dlpack` because PyTorch uses the same name
+        return VectorToDLPack(v);
+      });
 
   py::class_<SubVector<float>, VectorBase<float>>(m, "FloatSubVector")
       .def(py::init([](py::buffer b) {

--- a/src/pybind/matrix/vector_pybind.cc
+++ b/src/pybind/matrix/vector_pybind.cc
@@ -21,6 +21,7 @@
 
 #include "matrix/vector_pybind.h"
 
+#include "dlpack/dlpack_deleter.h"
 #include "matrix/kaldi-vector.h"
 
 using namespace kaldi;
@@ -44,19 +45,65 @@ void pybind_vector(py::module& m) {
            [](const VectorBase<float>& v, int i) { return v(i); })
       .def("__setitem__",
            [](VectorBase<float>& v, int i, float val) { v(i) = val; })
-      .def("numpy", [](VectorBase<float>* v) {
-        return py::array_t<float>(
-            {v->Dim()},       // shape
-            {sizeof(float)},  // stride in bytes
-            v->Data(),        // ptr
-            py::none());      // pass a base object to avoid copy!
-        // (fangjun): the base object can be anything containing a non-null
-        // ptr. I cannot think of a better way than to pass a `None` object.
-        //
-        // `numpy` instead of `Numpy`, `ToNumpy` or `SomeOtherName` is used here
-        // because we want to follow the style in PyKaldi and PyTorch using the
-        // method `numpy()` to convert a matrix/tensor to a numpy array.
+      .def("numpy",
+           [](VectorBase<float>* v) {
+             return py::array_t<float>(
+                 {v->Dim()},       // shape
+                 {sizeof(float)},  // stride in bytes
+                 v->Data(),        // ptr
+                 py::none());      // pass a base object to avoid copy!
+             // (fangjun): the base object can be anything containing a non-null
+             // ptr. I cannot think of a better way than to pass a `None`
+             // object.
+             //
+             // `numpy` instead of `Numpy`, `ToNumpy` or `SomeOtherName` is used
+             // here because we want to follow the style in PyKaldi and PyTorch
+             // using  the  method `numpy()` to convert a matrix/tensor to a
+             // numpy array.
+           })
+      .def("to_dlpack", [](VectorBase<float>* v) {
+        // we use the name `to_dlpack` because PyTorch uses the same name
+
+        // the created `managed_tensor` will be freed in
+        // `DLManagedTensorDeleter`, so no memory leak here.
+        auto* managed_tensor = new DLManagedTensor();
+        managed_tensor->manager_ctx = nullptr;
+
+        // setup the deleter to free allocated memory.
+        // refer to
+        // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L361
+        // for how and when the deleter is invoked.
+        managed_tensor->deleter = &DLManagedTensorDeleter;
+
+        auto* tensor = &managed_tensor->dl_tensor;
+        tensor->data = v->Data();
+        tensor->ctx.device_type = kDLCPU;
+        tensor->ctx.device_id = 0;
+
+        tensor->ndim = 1;
+
+        tensor->dtype.code = kDLFloat;
+        tensor->dtype.bits = 32;  // single precision float
+        tensor->dtype.lanes = 1;
+
+        // `shape` and `strides` are freed in `DLManagedTensorDeleter`, so
+        // no memory leak here .
+        tensor->shape = new int64_t[1];
+        tensor->shape[0] = v->Dim();
+
+        tensor->strides = new int64_t[1];
+        tensor->strides[0] = 1;
+        tensor->byte_offset = 0;
+
+        // WARNING(fangjun): the name of the capsule MUST be `dltensor` for
+        // PyTorch; refer to
+        // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L383/
+        // for more details
+        return py::capsule(managed_tensor, "dltensor");
       });
+
+  // TODO(fangjun): add `from_dlpack` once kaldi::Vector is changed to borrow a
+  // ptr from the outside
 
   py::class_<Vector<float>, VectorBase<float>>(m, "FloatVector",
                                                py::buffer_protocol())

--- a/src/pybind/matrix/vector_pybind.cc
+++ b/src/pybind/matrix/vector_pybind.cc
@@ -65,7 +65,8 @@ void pybind_vector(py::module& m) {
         // we use the name `to_dlpack` because PyTorch uses the same name
 
         // the created `managed_tensor` will be freed in
-        // `DLManagedTensorDeleter`, so no memory leak here.
+        // `DLManagedTensorDeleter`, which does not free `data`,
+        // so no memory leak here
         auto* managed_tensor = new DLManagedTensor();
         managed_tensor->manager_ctx = nullptr;
 
@@ -102,9 +103,6 @@ void pybind_vector(py::module& m) {
         return py::capsule(managed_tensor, "dltensor");
       });
 
-  // TODO(fangjun): add `from_dlpack` once kaldi::Vector is changed to borrow a
-  // ptr from the outside
-
   py::class_<Vector<float>, VectorBase<float>>(m, "FloatVector",
                                                py::buffer_protocol())
       .def_buffer([](const Vector<float>& v) -> py::buffer_info {
@@ -131,5 +129,27 @@ void pybind_vector(py::module& m) {
         }
         return new SubVector<float>(reinterpret_cast<float*>(info.ptr),
                                     info.shape[0]);
-      }));
+      }))
+      .def("from_dlpack", [](py::capsule* capsule) {
+        DLManagedTensor* managed_tensor = *capsule;
+        // (fangjun): the above assignment will either throw or succeed with a
+        // non-null ptr so no need to check for nullptr below
+
+        auto* tensor = &managed_tensor->dl_tensor;
+
+        // we support only 1-D tensor
+        KALDI_ASSERT(tensor->ndim == 1);
+
+        // we support only float (single precision, 32-bit) tensor
+        KALDI_ASSERT(tensor->dtype.code == kDLFloat);
+        KALDI_ASSERT(tensor->dtype.bits == 32);
+        KALDI_ASSERT(tensor->dtype.lanes == 1);
+
+        auto* ctx = &tensor->ctx;
+        KALDI_ASSERT(ctx->device_type == kDLCPU);
+
+        return SubVector<float>(reinterpret_cast<float*>(tensor->data),
+                                tensor->shape[0]);
+
+      });
 }

--- a/src/pybind/matrix/vector_pybind.cc
+++ b/src/pybind/matrix/vector_pybind.cc
@@ -21,7 +21,7 @@
 
 #include "matrix/vector_pybind.h"
 
-#include "dlpack/dlpack_deleter.h"
+#include "dlpack/dlpack_pybind.h"
 #include "matrix/kaldi-vector.h"
 
 using namespace kaldi;
@@ -63,44 +63,7 @@ void pybind_vector(py::module& m) {
            })
       .def("to_dlpack", [](VectorBase<float>* v) {
         // we use the name `to_dlpack` because PyTorch uses the same name
-
-        // the created `managed_tensor` will be freed in
-        // `DLManagedTensorDeleter`, which does not free `data`,
-        // so no memory leak here
-        auto* managed_tensor = new DLManagedTensor();
-        managed_tensor->manager_ctx = nullptr;
-
-        // setup the deleter to free allocated memory.
-        // refer to
-        // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L361
-        // for how and when the deleter is invoked.
-        managed_tensor->deleter = &DLManagedTensorDeleter;
-
-        auto* tensor = &managed_tensor->dl_tensor;
-        tensor->data = v->Data();
-        tensor->ctx.device_type = kDLCPU;
-        tensor->ctx.device_id = 0;
-
-        tensor->ndim = 1;
-
-        tensor->dtype.code = kDLFloat;
-        tensor->dtype.bits = 32;  // single precision float
-        tensor->dtype.lanes = 1;
-
-        // `shape` and `strides` are freed in `DLManagedTensorDeleter`, so
-        // no memory leak here .
-        tensor->shape = new int64_t[1];
-        tensor->shape[0] = v->Dim();
-
-        tensor->strides = new int64_t[1];
-        tensor->strides[0] = 1;
-        tensor->byte_offset = 0;
-
-        // WARNING(fangjun): the name of the capsule MUST be `dltensor` for
-        // PyTorch; refer to
-        // https://github.com/pytorch/pytorch/blob/master/torch/csrc/Module.cpp#L383/
-        // for more details
-        return py::capsule(managed_tensor, "dltensor");
+        return VectorToDLPack(v);
       });
 
   py::class_<Vector<float>, VectorBase<float>>(m, "FloatVector",
@@ -129,27 +92,11 @@ void pybind_vector(py::module& m) {
         }
         return new SubVector<float>(reinterpret_cast<float*>(info.ptr),
                                     info.shape[0]);
-      }))
-      .def("from_dlpack", [](py::capsule* capsule) {
-        DLManagedTensor* managed_tensor = *capsule;
-        // (fangjun): the above assignment will either throw or succeed with a
-        // non-null ptr so no need to check for nullptr below
+      }));
 
-        auto* tensor = &managed_tensor->dl_tensor;
-
-        // we support only 1-D tensor
-        KALDI_ASSERT(tensor->ndim == 1);
-
-        // we support only float (single precision, 32-bit) tensor
-        KALDI_ASSERT(tensor->dtype.code == kDLFloat);
-        KALDI_ASSERT(tensor->dtype.bits == 32);
-        KALDI_ASSERT(tensor->dtype.lanes == 1);
-
-        auto* ctx = &tensor->ctx;
-        KALDI_ASSERT(ctx->device_type == kDLCPU);
-
-        return SubVector<float>(reinterpret_cast<float*>(tensor->data),
-                                tensor->shape[0]);
-
-      });
+  py::class_<DLPackSubVector<float>, SubVector<float>>(m,
+                                                       "DLPackFloatSubVector")
+      .def("from_dlpack",
+           [](py::capsule* capsule) { return SubVectorFromDLPack(capsule); },
+           py::return_value_policy::take_ownership);
 }

--- a/src/pybind/tests/test_dlpack_subvector.cc
+++ b/src/pybind/tests/test_dlpack_subvector.cc
@@ -1,4 +1,4 @@
-// pybind/dlpck/dlpack_deleter.h
+// pybind/tests/test_dlpack_subvector.cc
 
 // Copyright 2019   Mobvoi AI Lab, Beijing, China
 //                  (author: Fangjun Kuang, Yaguang Hu, Jian Wang)
@@ -16,15 +16,23 @@
 // See the Apache 2 License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef KALDI_PYBIND_DLPACK_DLPACK_DELETER_H_
-#define KALDI_PYBIND_DLPACK_DLPACK_DELETER_H_
+#include "dlpack/dlpack_pybind.h"
 
-#include "dlpack/dlpack.h"
+// TODO(fangjun): remove this file if neccessary
+// this file is to show that we can pass
+// a DLPackSubVector to a function in C++
+// that accepts a pointer/reference to VectorBase<float>
 
-namespace kaldi {
+using namespace kaldi;
+namespace {
+void Hello(VectorBase<float>& vref, VectorBase<float>* vptr) {
+  KALDI_LOG << "dim of vref is: " << vref.Dim();
+  KALDI_LOG << "vptr[0] = " << (*vptr)(0);
+}
+}
 
-void DLManagedTensorDeleter(struct DLManagedTensor* dl_managed_tensor);
-
-}  // namespace kaldi
-
-#endif  // KALDI_PYBIND_DLPACK_DLPACK_DELETER_H_
+void test_dlpack(py::module& m) {
+  m.def("Hello", &Hello,
+        "For test only. Pass a DLPackSubVector to C++ that accepts a pointer "
+        "to VectorBase<float>");
+}

--- a/src/pybind/tests/test_dlpack_subvector.py
+++ b/src/pybind/tests/test_dlpack_subvector.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Mobvoi AI Lab, Beijing, China (author: Fangjun Kuang)
+# Apache 2.0
+
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
+
+import unittest
+
+try:
+    import torch
+except ImportError:
+    print('This test needs PyTorch.')
+    print('Please install PyTorch first.')
+    print('PyTorch 1.3.0dev20191006 has been tested and is guaranteed to work.')
+    sys.exit(0)
+
+from torch.utils.dlpack import to_dlpack
+
+import kaldi
+
+
+class TestDLPackSubVector(unittest.TestCase):
+
+    def test_dlpack_subvector(self):
+        '''
+        kaldi.Hello accepts two parameters:
+            Param 1: reference to VectorBase<float>
+            Param 2: pointer to VectorBase<float>
+
+        This test shows that we can pass a DLPackSubVector
+        to `Hello`.
+        '''
+        tensor1 = torch.tensor([1, 2]).float()
+        v1 = kaldi.SubVectorFromDLPack(to_dlpack(tensor1))
+
+        tensor2 = torch.tensor([10, 20, 30]).float()
+        v2 = kaldi.SubVectorFromDLPack(to_dlpack(tensor2))
+
+        kaldi.Hello(v1, v2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Actually, it can zero-copy Kaldi's CuVector/CuMatrix to
any DL frameworks that support the DLPack interface.

CuVector/Vector/CuMatrix/Matrix support ONLY `to_dlpack`.

Cu**Sub**Vector/**Sub**Vector/Cu**Sub**Matrix/**Sub**Matrix support
both `from_dlpack` and `to_dlpack`

